### PR TITLE
CUDA detection and settings (configure.ac - host code compiler + path priority)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1886,6 +1886,25 @@ then
         CUDA_LIB="-L\"$CUDA_LIB_PATH\" -lcudart"
 fi
 
+# CUDA host compiler
+HOST_CC_REPORT=""
+AC_ARG_WITH(cuda-host-compiler,
+	AC_HELP_STRING([--with-cuda-host-compiler=BINARY], [specify compiler used for building cuda host code]))
+if test "x${with_cuda_host_compiler}" != "x" ; then
+	AC_CHECK_PROG([cuda_host_cc], [${with_cuda_host_compiler}],[yes])
+	if test "x${cuda_host_cc}" = "xyes" ; then
+		NVCCFLAGS+=" -ccbin ${with_cuda_host_compiler}"
+	else
+		AC_MSG_FAILURE([Binary ${with_cuda_host_compiler} given as cuda host compiler, yet not found!])
+	fi
+else
+	with_cuda_host_compiler="default"
+fi
+
+if test "x$NVCC" != "X" ; then
+	HOST_CC_REPORT=" (host code compiler: ${with_cuda_host_compiler})"
+fi
+
 AC_SUBST(NVCC)
 AC_SUBST(FOUND_CUDA)
 AC_SUBST(CUDA_PATH)
@@ -2691,7 +2710,7 @@ RESULT=\
   License ..................... $license
   iHDTV support ............... $ihdtv
   OpenSSL-libcrypto ........... $crypto
-  CUDA support ................ $FOUND_CUDA
+  CUDA support ................ $FOUND_CUDA$HOST_CC_REPORT
   Library live555 ............. $livemedia
   Syphon ...................... $syphon
 

--- a/configure.ac
+++ b/configure.ac
@@ -1850,7 +1850,7 @@ AC_ARG_WITH(cuda,
             [CUDA_PATH=$withval
             ])
 
-AC_PATH_PROG(NVCC, nvcc, [], [$PATH$PATH_SEPARATOR$CUDA_PATH/bin]dnl
+AC_PATH_PROG(NVCC, nvcc, [], [$CUDA_PATH/bin$PATH_SEPARATOR$PATH]dnl
         [$PATH_SEPARATOR/opt/cuda/bin$PATH_SEPARATOR/usr/local/cuda/bin])
 
 if test -n "$NVCC" -a $cuda_req != no


### PR DESCRIPTION
First commit adds support for clang as CUDA host code compiler setting via configure. This is required to compile the UltraGrid on distributions equipt with gcc 5.4 and above, as cuda 8.0 does not support theese gcc versions.

Second commit fixes th order of paths searched for nvcc, according to the related path order comments.