### PR TITLE
increase hardcoded limit to the number of audio channels in wav header from 100 -> 128 in wav reader

### DIFF
--- a/src/audio/wav_reader.c
+++ b/src/audio/wav_reader.c
@@ -61,7 +61,7 @@ static int read_fmt_chunk(FILE *wav_file, struct wav_metadata *metadata)
 
         uint16_t ch_count;
         READ_N(&ch_count, 2);
-        if (ch_count > 100) {
+        if (ch_count > 128) {
                 return WAV_HDR_PARSE_INVALID_PARAM;
         }
         metadata->ch_count = ch_count;


### PR DESCRIPTION
seems that the actual max is 65534, increased as I am testing with 128 channels.
http://soundfile.sapp.org/doc/WaveFormat/ but I bet there are loads of off by 1 and signed and unsigned fun to be had.
128 fixes my problem :-)