### PR TITLE
More information on blackmagic decode and counters for out of order packets and duplicates

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -99,7 +99,7 @@ enum audio_transport_device {
         NET_STANDARD
 };
 
-#define DEFAULT_AUDIO_RECV_BUF_SIZE (256 * 1024)
+#define DEFAULT_AUDIO_RECV_BUF_SIZE (256 * 4096)
 
 struct audio_network_parameters {
         char *addr = nullptr;

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -625,8 +625,6 @@ static int display_decklink_putf(void *state, struct video_frame *frame, int non
                 double fps = (s->frames - s->frames_last) / seconds;
                 log_msg(LOG_LEVEL_INFO, MOD_NAME "%lu frames in %g seconds = %g FPS\n",
                         s->frames - s->frames_last, seconds, fps);
-                LOG(LOG_LEVEL_INFO) << MOD_NAME << s->frames - s->frames_last << " frames in " << seconds 
-                                    << " seconds = " << fps << " FPS" << std::endl;
                 LOG(LOG_LEVEL_INFO) << MOD_NAME "Frames cumulative " << s->state.at(0).delegate->frames_late
                                      << " late, " << s->state.at(0).delegate->frames_dropped 
                                      << " dropped, " << s->state.at(0).delegate->frames_flushed

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -630,7 +630,7 @@ static int display_decklink_putf(void *state, struct video_frame *frame, int non
                         s->frames - s->frames_last, seconds, fps);
                 LOG(LOG_LEVEL_INFO) << MOD_NAME << s->frames - s->frames_last << "frames in " << seconds 
                                     << " seconds = " << fps << " FPS" << std::endl;;
-                LOG(LOG_LEVEL_INFO) << MOD_NAME "Frames cumlative " << s->state.at(0).delegate->frames_late
+                LOG(LOG_LEVEL_INFO) << MOD_NAME "Frames cumulative " << s->state.at(0).delegate->frames_late
                                      << " late, " << s->state.at(0).delegate->frames_dropped 
                                      << " dropped, " << s->state.at(0).delegate->frames_flushed
                                      << " flushed." << std::endl;;

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -337,9 +337,6 @@ struct state_decklink {
 
         unsigned long int   frames;
         unsigned long int   frames_last;
-        unsigned long int   frames_dropped;
-        unsigned long int   frames_late;
-        unsigned long int   frames_flushed;
         bool                stereo;
         bool                initialized_audio;
         bool                initialized_video;
@@ -629,11 +626,11 @@ static int display_decklink_putf(void *state, struct video_frame *frame, int non
                 log_msg(LOG_LEVEL_INFO, MOD_NAME "%lu frames in %g seconds = %g FPS\n",
                         s->frames - s->frames_last, seconds, fps);
                 LOG(LOG_LEVEL_INFO) << MOD_NAME << s->frames - s->frames_last << " frames in " << seconds 
-                                    << " seconds = " << fps << " FPS" << std::endl;;
+                                    << " seconds = " << fps << " FPS" << std::endl;
                 LOG(LOG_LEVEL_INFO) << MOD_NAME "Frames cumulative " << s->state.at(0).delegate->frames_late
                                      << " late, " << s->state.at(0).delegate->frames_dropped 
                                      << " dropped, " << s->state.at(0).delegate->frames_flushed
-                                     << " flushed." << std::endl;;
+                                     << " flushed." << std::endl;
 
                 s->tv = tv;
                 s->frames_last = s->frames;

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -628,7 +628,7 @@ static int display_decklink_putf(void *state, struct video_frame *frame, int non
                 double fps = (s->frames - s->frames_last) / seconds;
                 log_msg(LOG_LEVEL_INFO, MOD_NAME "%lu frames in %g seconds = %g FPS\n",
                         s->frames - s->frames_last, seconds, fps);
-                LOG(LOG_LEVEL_INFO) << MOD_NAME << s->frames - s->frames_last << "frames in " << seconds 
+                LOG(LOG_LEVEL_INFO) << MOD_NAME << s->frames - s->frames_last << " frames in " << seconds 
                                     << " seconds = " << fps << " FPS" << std::endl;;
                 LOG(LOG_LEVEL_INFO) << MOD_NAME "Frames cumulative " << s->state.at(0).delegate->frames_late
                                      << " late, " << s->state.at(0).delegate->frames_dropped 


### PR DESCRIPTION
Also increased the audio receive buffer.
Provides stats on out of order packets and duplicates
Provides stats on the Decklink payback, so that we can see late frames count.