### PR TITLE
Update Capabilities to have Auto-detect modes.

### DIFF
--- a/src/video_capture/decklink.cpp
+++ b/src/video_capture/decklink.cpp
@@ -843,16 +843,34 @@ static struct vidcap_type *vidcap_decklink_probe(bool verbose, void (**deleter)(
                         }
                 }
 
-                if (i < (int) (sizeof vt->cards[vt->card_count - 1].modes /
-                                        sizeof vt->cards[vt->card_count - 1].modes[0])) {
-                        snprintf(vt->cards[vt->card_count - 1].modes[i].id,
-                                        sizeof vt->cards[vt->card_count - 1].modes[i].id,
-                                        "{\"modeOpt\":\"detect-format\"}");
-                        snprintf(vt->cards[vt->card_count - 1].modes[i].name,
-                                        sizeof vt->cards[vt->card_count - 1].modes[i].name,
-                                        "UltraGrid auto-detect");
-                        i++;
+                for (auto &c : connections) {
+                        if (i < (int) (sizeof vt->cards[vt->card_count - 1].modes /
+                                                sizeof vt->cards[vt->card_count - 1].modes[0])) {
+                                snprintf(vt->cards[vt->card_count - 1].modes[i].id,
+                                                sizeof vt->cards[vt->card_count - 1].modes[i].id,
+                                                "{\"modeOpt\":\"connection=%s\"}",
+                                                c.c_str());
+                                snprintf(vt->cards[vt->card_count - 1].modes[i].name,
+                                                sizeof vt->cards[vt->card_count - 1].modes[i].name,
+                                                "Decklink Auto (%s)", c.c_str());
+                                i++;
+                        }
                 }
+
+                for (auto &c : connections) {
+                        if (i < (int) (sizeof vt->cards[vt->card_count - 1].modes /
+                                                sizeof vt->cards[vt->card_count - 1].modes[0])) {
+                                snprintf(vt->cards[vt->card_count - 1].modes[i].id,
+                                                sizeof vt->cards[vt->card_count - 1].modes[i].id,
+                                                "{\"modeOpt\":\"detect-format:connection=%s\"}",
+                                                c.c_str());
+                                snprintf(vt->cards[vt->card_count - 1].modes[i].name,
+                                                sizeof vt->cards[vt->card_count - 1].modes[i].name,
+                                                "UltraGrid auto-detect (%s)", c.c_str());
+                                i++;
+                        }
+                }
+
 
                 // Increment the total number of DeckLink cards found
                 numDevices++;


### PR DESCRIPTION
This allows GUI to easily select the Autodetect by connection.

The first does Auto by the Decklink, then the UltraGrid is also available for cards that Auto-detect doesn't work on.