### PR TITLE
 Fix bug that causes deadlock when program quits

### DIFF
--- a/src/video_display/gl.cpp
+++ b/src/video_display/gl.cpp
@@ -68,15 +68,16 @@
 #include "spout_sender.h"
 #include "syphon_server.h"
 
+#include <array>
 #include <algorithm>
 #include <condition_variable>
 #include <csetjmp>
 #include <fstream>
 #include <iostream>
-#include <list>
 #include <mutex>
 #include <queue>
 #include <string>
+#include <string_view>
 
 #include "debug.h"
 #include "gl_context.h"
@@ -177,12 +178,16 @@ void main()
 } // main end
 )raw";
 
-const static list<pair<int64_t, string>> keybindings {{'f', "toggle fullscreen"},
-        {'q', "quit"}, {'d', "toggle deinterlace"}, {'p', "pause video"},
-        {K_ALT('s'), "screenshot"}, {K_ALT('c'), "show/hide cursor"},
+static constexpr array<pair<int64_t, string_view>, 8> keybindings{{
+        {'f', "toggle fullscreen"},
+        {'q', "quit"},
+        {'d', "toggle deinterlace"},
+        {'p', "pause video"},
+        {K_ALT('s'), "screenshot"},
+        {K_ALT('c'), "show/hide cursor"},
         {K_CTRL_DOWN, "make window 10% smaller"},
         {K_CTRL_UP, "make window 10% bigger"}
-};
+}};
 
 #ifdef HWACC_VDPAU
 struct state_vdpau {
@@ -545,7 +550,7 @@ static void * display_gl_init(struct module *parent, const char *fmt, unsigned i
         for (auto i : keybindings) {
                 char msg[18];
                 sprintf(msg, "%" PRIx64, i.first);
-                keycontrol_register_key(&s->mod, i.first, msg, i.second.c_str());
+                keycontrol_register_key(&s->mod, i.first, msg, i.second.data());
         }
 
         /* GLUT callbacks take only some arguments so we need static variable */

--- a/src/video_display/sdl.cpp
+++ b/src/video_display/sdl.cpp
@@ -384,7 +384,6 @@ static void display_sdl_run(void *arg)
                                 break;
                         case SDL_QUIT:
                                 exit_uv(0);
-                                break;
                         }
                 }
 	}

--- a/src/video_display/sdl2.cpp
+++ b/src/video_display/sdl2.cpp
@@ -73,12 +73,14 @@
 #endif // defined __arm64__
 #include <SDL2/SDL.h>
 
+#include <array>
+#include <cassert>
 #include <condition_variable>
 #include <cstdint>
-#include <list>
 #include <mutex>
 #include <queue>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility> // pair
 
@@ -147,8 +149,12 @@ struct state_sdl2 {
                 module_done(&mod);
         }
 };
-static const list<pair<char, string>> display_sdl2_keybindings{{'d', "toggle deinterlace"},
-        {'f', "toggle fullscreen"}, {'q', "quit"}};
+
+static constexpr array<pair<char, string_view>, 3> display_sdl2_keybindings{{
+        {'d', "toggle deinterlace"},
+        {'f', "toggle fullscreen"}, 
+        {'q', "quit"} 
+}};
 
 static void display_frame(struct state_sdl2 *s, struct video_frame *frame)
 {
@@ -335,7 +341,6 @@ static void display_sdl2_run(void *arg)
                         }
                 } else if (sdl_event.type == SDL_QUIT) {
                         exit_uv(0);
-                        break;
                 }
         }
 }
@@ -641,7 +646,7 @@ static void *display_sdl2_init(struct module *parent, const char *fmt, unsigned 
 
         loadSplashscreen(s);
         for (auto i : display_sdl2_keybindings) {
-                keycontrol_register_key(&s->mod, i.first, to_string(static_cast<int>(i.first)).c_str(), i.second.c_str());
+                keycontrol_register_key(&s->mod, i.first, to_string(static_cast<int>(i.first)).c_str(), i.second.data());
         }
 
         log_msg(LOG_LEVEL_NOTICE, "SDL2 initialized successfully.\n");


### PR DESCRIPTION
SDL displays sometimes cause deadlock. If they received QUIT signal, they immediately stopped pulling frames from their frame queue.  If the frame queue was full, it caused deadlock because the receiver could not push the last frame(poison pill) in the queue.
Solution: SDL displays now don't end until the poison pill is received.

+ refactor: store display keybindings as compile-time constants