### PR TITLE
[rtp] fix display_buf_increase_warning warning

### DIFF
--- a/src/video_rxtx/rtp.cpp
+++ b/src/video_rxtx/rtp.cpp
@@ -359,7 +359,7 @@ struct rtp **rtp_video_rxtx::initialize_network(const char *addrs, int recv_port
 
                 int size = INITIAL_VIDEO_RECV_BUFFER_SIZE;
                 int ret = rtp_set_recv_buf(devices[index], INITIAL_VIDEO_RECV_BUFFER_SIZE);
-                if (ret != 0) {
+                if (ret != TRUE) {
                         display_buf_increase_warning(size);
                 }
 


### PR DESCRIPTION
rtp_set_recv_buf returns TRUE on success, which is #define'd to 1. Fix the logic in the check so the warning does not print erroneously.

I also see there are various uses of TRUE/FALSE from src/config_unix.h, true/false in C files from <stdbool>, as well as C++ true/false (including C files with .cpp extension). It might be nice to unify this in the future, what do you think?