### PR TITLE
[decklink] fix stereo 3D supportedFlags

### DIFF
--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -779,7 +779,7 @@ display_decklink_reconfigure_video(void *state, struct video_desc desc)
 
                 if (s->stereo) {
                         outputFlags = (BMDVideoOutputFlags) (outputFlags | bmdVideoOutputDualStream3D);
-                        supportedFlags = (BMDSupportedVideoModeFlags) (outputFlags | bmdSupportedVideoModeDualStream3D);
+                        supportedFlags = (BMDSupportedVideoModeFlags) (supportedFlags | bmdSupportedVideoModeDualStream3D);
                 }
 
                 BMD_BOOL subsampling_444 = codec_is_a_rgb(desc.color_spec); // we don't have pixfmt for 444 YCbCr


### PR DESCRIPTION
Fix a small bug in decklink video_display where supportedFlags is accidentally merged with outputFlags.

The bug results in supportedFlags getting set to bmdVideoOutputDualStream3D (16) | bmdSupportedVideoModeDualStream3D (2) == 18, but in the context of BMDSupportedVideoModeFlags the 16 means bmdSupportedVideoModeSDIQuadLink and thus causes failures on cards that do not support quad-link.

For example, this bug is benign on DeckLink 8K Pro, but will cause issues on DeckLink 4K Extreme 12G.

Also of note, and not solved here, is that the EXIT_IF_FAILED macro will not successfully terminate from within display_decklink_reconfigure_video.