### PR TITLE
Added dynamic resampling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ext-deps/zfec"]
 	path = ext-deps/zfec
 	url = https://github.com/tahoe-lafs/zfec
+[submodule "ext-deps/soxr"]
+	path = ext-deps/soxr
+	url = https://github.com/chirlu/soxr.git

--- a/configure.ac
+++ b/configure.ac
@@ -2592,6 +2592,26 @@ elif test "$found_speexdsp" = no -a "$speexdsp_req" != no; then
 fi
 
 # ---------------------------------------------------------------------------
+# SOXR
+# ---------------------------------------------------------------------------
+soxr=no
+
+AC_ARG_ENABLE(soxr,
+              AS_HELP_STRING([--disable-soxr], [disable Soxr (default is auto)]),
+              [soxr_req=$enableval],
+              [soxr_req=$build_default])
+PKG_CHECK_MODULES([LIBSOXR], [soxr], [found_soxr=yes], [found_soxr=no])
+
+if test "$found_soxr" = yes -a "$soxr_req" != no; then
+        LIBS="$LIBS $LIBSOXR_LIBS"
+        COMMON_FLAGS="$COMMON_FLAGS${SOXR_COMMON_FLAGS:+${COMMON_FLAGS:+ }}$SOXR_COMMON_FLAGS"
+        AC_DEFINE([HAVE_SOXR], [1], [Build with Soxr support])
+        soxr=yes
+elif test "$soxr_req" = yes; then
+        AC_MSG_ERROR([Soxr not found]);
+fi
+
+# ---------------------------------------------------------------------------
 # Zfec
 # ---------------------------------------------------------------------------
 zfec=no
@@ -3467,6 +3487,7 @@ RESULT=`add_column "$RESULT" "Profiling support" $profile $?`
 RESULT=`add_column "$RESULT" "Qt GUI" $qt_gui $?`
 RESULT=`add_column "$RESULT" "RT priority" $use_rt $?`
 RESULT=`add_column "$RESULT" "SpeexDSP" $speexdsp $?`
+RESULT=`add_column "$RESULT" "Soxr" $soxr $?`
 RESULT=`add_column "$RESULT" "Standalone modules" $build_libraries $?`
 RESULT=`add_column "$RESULT" "zfec" $zfec $?`
 RESULT=`end_section "$RESULT"`

--- a/src/audio/types.cpp
+++ b/src/audio/types.cpp
@@ -441,7 +441,8 @@ void audio_frame2::convert_int32_to_float() {
                 auto channel_data_length =  this->get_data_len(i);
                 for(size_t j = 0; j < channel_data_length / this->bps; j++) {
                         int32_t *p_curr_value = (int32_t *)(channel_data + (this->bps * j));
-                        *p_curr_value = (float)(*p_curr_value / std::numeric_limits<int32_t>::max());
+                        float *p_curr_value_float = (float *)p_curr_value;
+                        *p_curr_value_float = ((float)(*p_curr_value) / (float)std::numeric_limits<int32_t>::max());
                 }
         }
 }
@@ -459,14 +460,16 @@ void audio_frame2::convert_float_to_int32() {
                 auto channel_data_length =  this->get_data_len(i);
                 for(size_t j = 0; j < channel_data_length / this->bps; j++) {
                         float *p_curr_value = (float *)(channel_data + (this->bps * j));
+                        int32_t *p_curr_value_int = (int32_t *)p_curr_value;
+
                         if((*p_curr_value) > 1) {
-                                *p_curr_value = std::numeric_limits<int32_t>::max();
+                                *p_curr_value_int = std::numeric_limits<int32_t>::max();
                         }
                         else if((*p_curr_value) < -1) {
-                                *p_curr_value = std::numeric_limits<int32_t>::min();
+                                *p_curr_value_int = std::numeric_limits<int32_t>::min();
                         }
                         else {
-                                *p_curr_value = (int32_t)std::roundf((*p_curr_value) * std::numeric_limits<int32_t>::max());
+                                *p_curr_value_int = (int32_t)roundf((*p_curr_value) * std::numeric_limits<int32_t>::max());
                         }
                 }
         }

--- a/src/audio/types.cpp
+++ b/src/audio/types.cpp
@@ -51,6 +51,10 @@
 #include <speex/speex_resampler.h>
 #endif // HAVE_SPEEXDSP
 
+#ifdef HAVE_SOXR
+#include <soxr.h>
+#endif // HAVE_SOXR
+
 #include <cmath>
 #include <sstream>
 #include <stdexcept>
@@ -84,8 +88,8 @@ audio_desc::operator string() const
 
 audio_frame2_resampler::~audio_frame2_resampler() {
         if (resampler) {
-#ifdef HAVE_SPEEXDSP
-                speex_resampler_destroy((SpeexResamplerState *) resampler);
+#ifdef HAVE_SOXR                
+                soxr_delete((soxr_t) resampler);
 #endif
         }
 }
@@ -178,8 +182,10 @@ int audio_frame2_resampler::get_resampler_initial_bps() {
         return this->resample_initial_bps;
 }
 
-ADD_TO_PARAM("resampler-quality", "* resampler-quality=[0-10]\n"
-                "  Sets audio resampler quality in range 0 (worst) and 10 (best), default " TOSTRING(DEFAULT_RESAMPLE_QUALITY) "\n");
+ADD_TO_PARAM("resampler-threaded", "* resampler-threaded\n"
+                "  Sets audio resampler to use threads (1 per channel).\n" \
+                "  This should only be used with large buffer sizes otherwise there is a risk\n" \
+                "  that there is additional overhead created by threading.\n");
 
 /**
  * @brief This function will create (and destroy) a new resampler.
@@ -194,43 +200,64 @@ ADD_TO_PARAM("resampler-quality", "* resampler-quality=[0-10]\n"
  * @return false Initialisation of the resampler failed
  */
 bool audio_frame2_resampler::create_resampler(uint32_t original_sample_rate, uint32_t new_sample_rate_num, uint32_t new_sample_rate_den, size_t channel_size, int bps) {
-#ifdef HAVE_SPEEXDSP
-        LOG(LOG_LEVEL_VERBOSE) << "Destroying Resampler\n";
+#ifdef HAVE_SOXR
         if (this->resampler) {
-                speex_resampler_destroy((SpeexResamplerState *) this->resampler);
+                soxr_delete((soxr_t)this->resampler);
                 this->destroy_resampler = false;
         }
         this->resampler = nullptr;
 
-        int quality = DEFAULT_RESAMPLE_QUALITY;
-        if (commandline_params.find("resampler-quality") != commandline_params.end()) {
-                quality = stoi(commandline_params.at("resampler-quality"));
-                assert(quality >= 0 && quality <= 10);
+        /* When creating a var-rate resampler, q_spec must be set as follows: */
+        soxr_quality_spec_t q_spec = soxr_quality_spec(SOXR_HQ, SOXR_VR);
+        // Use a low amount of threads because UltraGrid only provides a small audio buffer
+        // and multi-threading provides little (or worse) performance than being single threaded
+        int threads = 1;
+        if (commandline_params.find("resampler-threaded") != commandline_params.end()) {
+                // If someone has requested that threads are used then 
+                // we should get the thread count to match
+                // the amount of channels being resampled.
+                LOG(LOG_LEVEL_INFO) << "[audio_frame2] Setting the resampler to have " << channel_size << " threads\n";
+                threads = channel_size;
         }
-        int err = 0;
-        this->resampler = speex_resampler_init_frac(channel_size, original_sample_rate * new_sample_rate_den, new_sample_rate_num,
-                                                    original_sample_rate, new_sample_rate_num / new_sample_rate_den, quality, &err);
-        if (err) {
-                LOG(LOG_LEVEL_ERROR) << "[audio_frame2_resampler] Cannot initialize resampler: " << speex_resampler_strerror(err) << "\n";
+        soxr_runtime_spec_t const runtime_spec = soxr_runtime_spec(1);
+        soxr_io_spec_t io_spec;
+        if(bps == 2) {
+                io_spec = soxr_io_spec(SOXR_INT16_S, SOXR_INT16_S);
+        }
+        else if (bps == 4) {
+                io_spec = soxr_io_spec(SOXR_INT32_S, SOXR_INT32_S);
+        }
+        else {
+                LOG(LOG_LEVEL_ERROR) << "[audio_frame2_resampler] Unsupported BPS of: " << bps << "\n";  
                 return false;
         }
-        // Ignore resampler delay. The speex resampler silently adds a delay to the resampler by adding silence at the length
-        // of the input latency and stored a buffered amount for itself. This is extracted outside of this function on the final
-        // call before a resampler is marked for destruction.
-        speex_resampler_skip_zeros((SpeexResamplerState *) this->resampler);
-        this->resample_from = original_sample_rate;
+        
+        
+        soxr_error_t error;
+        /* The ratio of the given input rate and output rates must equate to the
+         * maximum I/O ratio that will be used. A resample rate of 2 to 1 would be excessive,
+           but provides a sensible ceiling */
+        this->resampler = soxr_create(2, 1, channel_size, &error, &io_spec, &q_spec, &runtime_spec);
+
+        if (error) {
+                LOG(LOG_LEVEL_ERROR) << "[audio_frame2_resampler] Cannot initialize resampler: " << soxr_strerror(error) << "\n";
+                return false;
+        }
+        // Immediately change the resample rate to be the correct value for the audio frame
+        soxr_set_io_ratio((soxr_t)this->resampler, ((double)original_sample_rate / ((double)new_sample_rate_num / (double)new_sample_rate_den)), 0);
 
         // Setup resampler values
+        this->resample_from = original_sample_rate;
         this->resample_to_num = new_sample_rate_num;
         this->resample_to_den = new_sample_rate_den;
         this->resample_ch_count = channel_size;
         // Capture the input and output latency. Generally, there is not a difference between the two.
         // The input latency is used to calculate leftover audio in the resampler that is collected on the
         // audio frame before the resampler is destroyed.
-        this->resample_input_latency = speex_resampler_get_input_latency((SpeexResamplerState *) this->resampler);
-        this->resample_output_latency = speex_resampler_get_output_latency((SpeexResamplerState *) this->resampler);
+        this->resample_input_latency = 0;
+        this->resample_output_latency = 0;
         this->resample_initial_bps = bps;
-        LOG(LOG_LEVEL_ERROR) << "[audio_frame2] Resampler (re)made at " << new_sample_rate_num / new_sample_rate_den << "\n";
+        LOG(LOG_LEVEL_DEBUG) << "[audio_frame2] Resampler (re)made at " << new_sample_rate_num / new_sample_rate_den << "\n";
         return true;
 #endif
         return false;
@@ -533,149 +560,71 @@ void audio_frame2::convert_float_to_int32() {
         }
 }
 
-/**
- * @brief A static function for resampling a single channel using the speex integer resampler.
- *        This is used to thread the resampling for all channels simultaneously.
- * 
- * @param resampler_state A pointer to resample state object which contains the Speex resampler state.
- * @param channel_index The channel index which is resampled.
- * @param in  A pointer to the 16bit integer data for the channel that is being resampled.
- * @param in_len The length in samples of the inputted data.
- * @param new_channel A pointer to the channel that is going to be written to.
- * @param remainder A pointer to an audio frame to capture lost audio if the resampler fails to resample all of the given data.
- */
-void audio_frame2::resample_channel(audio_frame2_resampler* resampler_state, int channel_index, const uint16_t *in, uint32_t in_len, channel *new_channel, audio_frame2 *remainder) {
-#ifdef HAVE_SPEEXDSP
-        uint32_t in_len_orig = in_len;
-        uint32_t out_len = new_channel->len;
-
-        speex_resampler_process_int(
-                        (SpeexResamplerState *) resampler_state->resampler,
-                        channel_index,
-                        (const spx_int16_t *)in, &in_len,
-                        (spx_int16_t *)(void *) new_channel->data.get(), &out_len);
-        if (in_len != in_len_orig) {
-                remainder->append(channel_index, (char *)(in + (in_len * sizeof(int16_t))), in_len_orig - in_len);
-        }
-        // The speex resampler process returns the number of frames written + 1 (so ensure we subtract 1 when setting the length)
-        new_channel->len = out_len * sizeof(int16_t);
-#else
-        LOG(LOG_LEVEL_ERROR) << "Audio frame resampler: cannot resample, SpeexDSP was not compiled in!\n";
-#endif
-}
-
-/**
- * @brief A static function for resampling a single channel using the speex floating point resampler.
- *        This is used to thread the resampling for all channels simultaneously.
- * 
- * @param resampler_state A pointer to resample state object which contains the Speex resampler state.
- * @param channel_index The channel index which is resampled.
- * @param in  A pointer to the floating point data for the channel that is being resampled.
- * @param in_len The length in samples of the inputted data.
- * @param new_channel A pointer to the channel that is going to be written to.
- * @param remainder A pointer to an audio frame to capture lost audio if the resampler fails to resample all of the given data.
- */
-void audio_frame2::resample_channel_float(audio_frame2_resampler* resampler_state, int channel_index, const float *in, uint32_t in_len, channel *new_channel, audio_frame2 *remainder) {
-#ifdef HAVE_SPEEXDSP
-        uint32_t in_len_orig = in_len;
-        uint32_t out_len = new_channel->len;
-        speex_resampler_process_float(
-                        (SpeexResamplerState *) resampler_state->resampler,
-                        channel_index,
-                        in, &in_len,
-                        (float *)(void *) new_channel->data.get(), &out_len);
-        if (in_len != in_len_orig) {
-                remainder->append(channel_index, (char *)(in + (in_len * sizeof(float))), in_len_orig - in_len);
-        }
-        // The speex resampler process returns the number of frames written + 1 (so ensure we subtract 1 when setting the length)
-        new_channel->len = out_len * sizeof(float);
-#else
-        LOG(LOG_LEVEL_ERROR) << "Audio frame resampler: cannot resample, SpeexDSP was not compiled in!\n";
-#endif
-}
-
 tuple<bool, bool, audio_frame2> audio_frame2::resample_fake([[maybe_unused]] audio_frame2_resampler & resampler_state, int new_sample_rate_num, int new_sample_rate_den)
 {
-        if (new_sample_rate_num / new_sample_rate_den == sample_rate && new_sample_rate_num % new_sample_rate_den == 0) {
-                return {true, false, audio_frame2()};
-        }
-
-        // If there is resampling occuring then time how long the function takes.
-        std::chrono::high_resolution_clock::time_point resample_begin = std::chrono::high_resolution_clock::now();
-
         // Track whether or not the resampler was reinitialised so that there is not an attempt to pull the latency buffer
         // from the resampler
         bool reinitialised_resampler = false;
-#ifdef HAVE_SPEEXDSP
-        // Speex has support for both 16bit audio and floating point 32bit audio
-        if (this->bps != 2 && this->bps != 4) {
-                LOG(LOG_LEVEL_DEBUG) << " Resample unsupported BPS " << bps << "\n";
-                throw logic_error("Only 16 bits per sample are currently supported for resampling!");
-        }
+        std::chrono::high_resolution_clock::time_point funcBegin = std::chrono::high_resolution_clock::now();
 
-        if ((sample_rate != resampler_state.resample_from
-                        || new_sample_rate_num != resampler_state.resample_to_num || new_sample_rate_den != resampler_state.resample_to_den
-                        || channels.size() != resampler_state.resample_ch_count) || resampler_state.resample_initial_bps != this->bps
-                        || resampler_state.destroy_resampler) {
+#ifdef HAVE_SOXR
+        if (!resampler_state.resampler_is_set()) {
                 reinitialised_resampler = resampler_state.create_resampler(this->sample_rate, new_sample_rate_num, new_sample_rate_den, this->channels.size(), this->bps);
                 if(!reinitialised_resampler) {
                         return {false, false, audio_frame2{}};
                 }
-                LOG(LOG_LEVEL_ERROR) << "[audio_frame2] Resampler (re)made at " << new_sample_rate_num / new_sample_rate_den << "\n";
+        }
+
+        if (sample_rate != resampler_state.resample_from
+                        || new_sample_rate_num != resampler_state.resample_to_num 
+                        || new_sample_rate_den != resampler_state.resample_to_den) {
+                // Update the resampler numerator and denomintors
+                resampler_state.resample_to_num = new_sample_rate_num;
+                resampler_state.resample_to_den = new_sample_rate_den;
+                soxr_set_io_ratio((soxr_t)resampler_state.resampler, ((double)this->sample_rate / ((double)new_sample_rate_num / (double)new_sample_rate_den)), 0);
         }
 
         // Initialise the new channels that the resampler is going to write into
+        void * * const obuf_ptrs = (void * *) malloc(sizeof(void *) * this->channels.size());
+        void * *       ibuf_ptrs = (void * *) malloc(sizeof(void *) * this->channels.size());
+
         std::vector<channel> new_channels(channels.size());
         for (size_t i = 0; i < channels.size(); i++) {
                 // allocate new storage + 10 ms headroom
                 size_t new_size = (long long) channels[i].len * new_sample_rate_num / sample_rate / new_sample_rate_den
                         + new_sample_rate_num * this->bps / 100 / new_sample_rate_den;
                 new_channels[i] = {unique_ptr<char []>(new char[new_size]), new_size, new_size, {}};
+
+                // Setup the buffers
+                obuf_ptrs[i] = new_channels[i].data.get();
+                ibuf_ptrs[i] = this->channels[i].data.get();
         }
 
-        audio_frame2 remainder;
-        remainder.init(get_channel_count(), get_codec(), get_bps(), get_sample_rate());
-
-        // Thread pool the resampling of the threads
-        std::vector<std::thread> resampleChannelThreads;
-        for (size_t i = 0; i < channels.size(); i++) {
-                // If the bytes per sample is 2, then use the integer based speex resampler
-                if(bps == 2) {
-                        resampleChannelThreads.push_back(std::thread(audio_frame2::resample_channel, &resampler_state, i,  
-                                                         (const uint16_t *)(const void *) get_data(i), 
-                                                         (int)(get_data_len(i) / sizeof(int16_t)), &(new_channels[i]), &remainder));
-                }
-                // If the bytes per sample is 4, then use the floating point based speex resampler
-                else if(bps == 4) {
-                        resampleChannelThreads.push_back(std::thread(audio_frame2::resample_channel_float, &resampler_state, i,  
-                                                         (const float *)(const void *) get_data(i), 
-                                                         (int)(get_data_len(i) / sizeof(float)), &(new_channels[i]), &remainder));
-                }
+        size_t inlen = this->get_data_len(0) / this->bps;
+        size_t outlen = new_channels[0].len / this->bps;
+        size_t odone = 0;
+        soxr_error_t error;
+        error = soxr_process((soxr_t)(resampler_state.resampler), ibuf_ptrs, inlen, NULL, obuf_ptrs, outlen, &odone);
+        if (error) {
+                LOG(LOG_LEVEL_ERROR) << "[audio_frame2_resampler] resampler failed: " << soxr_strerror(error) << "\n";
+                return {false, false, audio_frame2{}};
         }
-
-        // Join the threads before copying the data across
-        for(size_t i = 0; i < channels.size(); i++) {
-                resampleChannelThreads[i].join();
-        }
-
-        if (remainder.get_data_len() == 0) {
-                remainder = {};
+        for(int i = 0; i < new_channels.size(); i++) {
+                new_channels[i].len = odone * this->bps;
         }
 
         channels = move(new_channels);
+        free(obuf_ptrs); free(ibuf_ptrs);
 
-        std::chrono::high_resolution_clock::time_point resample_end = std::chrono::high_resolution_clock::now();
-        auto time_diff = std::chrono::duration_cast<std::chrono::duration<double>>(resample_end - resample_begin);
-        LOG(LOG_LEVEL_DEBUG) << "CALL LENGTH RESAMPLER " << setprecision(30) << time_diff.count() << "\n";
+        std::chrono::high_resolution_clock::time_point funcEnd = std::chrono::high_resolution_clock::now();
+        long long resamplerDuration = std::chrono::duration_cast<std::chrono::milliseconds>(funcEnd - funcBegin).count();
+        LOG(LOG_LEVEL_VERBOSE) << "[audio_frame2_resampler] resampler_duration " << resamplerDuration << "\n";
 
+        // Remainders aren't as relevant when using SOXR
+        audio_frame2 remainder = {};
         return {true, reinitialised_resampler, std::move(remainder)};
 #else
-        UNUSED(resampler_state.resample_from);
-        UNUSED(resampler_state.resample_to_num);
-        UNUSED(resampler_state.resample_to_den);
-        UNUSED(resampler_state.resample_ch_count);
-        LOG(LOG_LEVEL_ERROR) << "Audio frame resampler: cannot resample, SpeexDSP was not compiled in!\n";
-        return {false, reinitialised_resampler, audio_frame2{}};
+        return {false, false, audio_frame2{}};
 #endif
 }
 

--- a/src/audio/types.cpp
+++ b/src/audio/types.cpp
@@ -181,6 +181,18 @@ int audio_frame2_resampler::get_resampler_initial_bps() {
 ADD_TO_PARAM("resampler-quality", "* resampler-quality=[0-10]\n"
                 "  Sets audio resampler quality in range 0 (worst) and 10 (best), default " TOSTRING(DEFAULT_RESAMPLE_QUALITY) "\n");
 
+/**
+ * @brief This function will create (and destroy) a new resampler.
+ * 
+ * @param original_sample_rate The original sample rate in Hz
+ * @param new_sample_rate_num  The numerator of the new sample rate
+ * @param new_sample_rate_den  The denominator of the new sample rate
+ * @param channel_size         The number of channels that will be resampled
+ * @param bps                  The bit rate (in bytes) of the incoming audio
+ * 
+ * @return true  Successfully created the resampler
+ * @return false Initialisation of the resampler failed
+ */
 bool audio_frame2_resampler::create_resampler(uint32_t original_sample_rate, uint32_t new_sample_rate_num, uint32_t new_sample_rate_den, size_t channel_size, int bps) {
 #ifdef HAVE_SPEEXDSP
         LOG(LOG_LEVEL_VERBOSE) << "Destroying Resampler\n";

--- a/src/audio/types.cpp
+++ b/src/audio/types.cpp
@@ -586,12 +586,12 @@ tuple<bool, bool, audio_frame2> audio_frame2::resample_fake([[maybe_unused]] aud
         std::vector<std::thread> resampleChannelThreads;
         for (size_t i = 0; i < channels.size(); i++) {
                 // if(bps == 2) {
-                        // resampleChannelThreads.push_back(std::thread(audio_frame2::resample_channel, &resampler_state, i,  
-                        //                                  (const uint16_t *)(const void *) get_data(i), 
-                        //                                  (int)(get_data_len(i) / sizeof(int16_t)), &(new_channels[i]), &remainder));
-                        audio_frame2::resample_channel(&resampler_state, i,  
-                                                (const uint16_t *)(const void *) get_data(i), 
-                                                (int)(get_data_len(i) / sizeof(int16_t)), &(new_channels[i]), &remainder);
+                        resampleChannelThreads.push_back(std::thread(audio_frame2::resample_channel, &resampler_state, i,  
+                                                         (const uint16_t *)(const void *) get_data(i), 
+                                                         (int)(get_data_len(i) / sizeof(int16_t)), &(new_channels[i]), &remainder));
+                        // audio_frame2::resample_channel(&resampler_state, i,  
+                        //                         (const uint16_t *)(const void *) get_data(i), 
+                        //                         (int)(get_data_len(i) / sizeof(int16_t)), &(new_channels[i]), &remainder);
                         // LOG(LOG_LEVEL_VERBOSE) << "Calling int resampler\n";
                 // }
                 // else if(bps == 4) {
@@ -605,9 +605,9 @@ tuple<bool, bool, audio_frame2> audio_frame2::resample_fake([[maybe_unused]] aud
                 // }
         }
 
-        // for(size_t i = 0; i < channels.size(); i++) {
-        //         resampleChannelThreads[i].join();
-        // }
+        for(size_t i = 0; i < channels.size(); i++) {
+                resampleChannelThreads[i].join();
+        }
 
         if (remainder.get_data_len() == 0) {
                 remainder = {};

--- a/src/audio/types.cpp
+++ b/src/audio/types.cpp
@@ -53,6 +53,7 @@
 
 #include <sstream>
 #include <stdexcept>
+#include <chrono>
 
 #define DEFAULT_RESAMPLE_QUALITY 10 // in range [0,10] - 10 best
 
@@ -342,6 +343,7 @@ ADD_TO_PARAM("resampler-quality", "* resampler-quality=[0-10]\n"
 
 tuple<bool, audio_frame2> audio_frame2::resample_fake([[maybe_unused]] audio_frame2_resampler & resampler_state, int new_sample_rate_num, int new_sample_rate_den)
 {
+        std::chrono::high_resolution_clock::time_point funcBegin = std::chrono::high_resolution_clock::now();
         if (new_sample_rate_num / new_sample_rate_den == sample_rate && new_sample_rate_num % new_sample_rate_den == 0) {
                 return {true, audio_frame2()};
         }
@@ -416,6 +418,11 @@ tuple<bool, audio_frame2> audio_frame2::resample_fake([[maybe_unused]] audio_fra
         }
 
         channels = move(new_channels);
+
+        std::chrono::high_resolution_clock::time_point funcEnd = std::chrono::high_resolution_clock::now();
+        auto timeDiff = std::chrono::duration_cast<std::chrono::duration<double>>(funcEnd - funcBegin);
+        LOG(LOG_LEVEL_VERBOSE) << " call diff resampler " << setprecision(3) << timeDiff.count() << "\n";
+
         return {true, std::move(remainder)};
 #else
         UNUSED(resampler_state.resample_from);

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -113,6 +113,7 @@ typedef struct
 
 #ifdef __cplusplus
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -120,13 +121,13 @@ class audio_frame2;
 
 class audio_frame2_resampler {
 public:
-        audio_frame2_resampler();
         ~audio_frame2_resampler();
 private:
-        void *resampler; // type is (SpeexResamplerState *)
-        int resample_from;
-        size_t resample_ch_count;
-        int resample_to;
+        void *resampler{nullptr}; // type is (SpeexResamplerState *)
+        int resample_from{0};
+        int resample_to_num{0};
+        int resample_to_den{1};
+        size_t resample_ch_count{0};
 
         friend class audio_frame2;
 };
@@ -184,6 +185,9 @@ public:
          * @retval false          if SpeexDSP was not compiled in
          */
         bool resample(audio_frame2_resampler &resampler_state, int new_sample_rate);
+
+        ///@ resamples to new sample rate while keeping nominal sample rate intact
+        std::tuple<bool, audio_frame2> resample_fake(audio_frame2_resampler & resampler_state, int new_sample_rate_num, int new_sample_rate_den);
 private:
         struct channel {
                 std::unique_ptr<char []> data;

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -126,7 +126,10 @@ public:
         int get_resampler_denominator();
         int get_resampler_output_latency();
         int get_resampler_input_latency();
-        bool resampler_set();
+        int get_resampler_from_sample_rate();
+        size_t get_resampler_channel_count();
+        bool resampler_is_set();
+        void resample_set_destroy_flag(bool destroy);
 private:
         void *resampler{nullptr}; // type is (SpeexResamplerState *)
         int resample_from{0};
@@ -135,6 +138,7 @@ private:
         int resample_output_latency{0};
         int resample_input_latency{0};
         size_t resample_ch_count{0};
+        bool destroy_resampler{false};
 
         friend class audio_frame2;
 };
@@ -192,10 +196,10 @@ public:
          *                        properties.
          * @retval false          if SpeexDSP was not compiled in
          */
-        bool resample(audio_frame2_resampler &resampler_state, int new_sample_rate);
+        std::tuple<bool, bool> resample(audio_frame2_resampler &resampler_state, int new_sample_rate);
 
         ///@ resamples to new sample rate while keeping nominal sample rate intact
-        std::tuple<bool, audio_frame2> resample_fake(audio_frame2_resampler & resampler_state, int new_sample_rate_num, int new_sample_rate_den);
+        std::tuple<bool, bool, audio_frame2> resample_fake(audio_frame2_resampler & resampler_state, int new_sample_rate_num, int new_sample_rate_den);
 private:
         struct channel {
                 std::unique_ptr<char []> data;

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -122,11 +122,18 @@ class audio_frame2;
 class audio_frame2_resampler {
 public:
         ~audio_frame2_resampler();
+        int get_resampler_numerator();
+        int get_resampler_denominator();
+        int get_resampler_output_latency();
+        int get_resampler_input_latency();
+        bool resampler_set();
 private:
         void *resampler{nullptr}; // type is (SpeexResamplerState *)
         int resample_from{0};
         int resample_to_num{0};
         int resample_to_den{1};
+        int resample_output_latency{0};
+        int resample_input_latency{0};
         size_t resample_ch_count{0};
 
         friend class audio_frame2;
@@ -169,6 +176,7 @@ public:
         bool has_same_prop_as(audio_frame2 const &frame) const;
         void set_duration(double duration);
         void set_fec_params(int channel, fec_desc const &);
+        void check_data(const char* location);
         static audio_frame2 copy_with_bps_change(audio_frame2 const &frame, int new_bps);
         void change_bps(int new_bps);
         /**

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -130,6 +130,7 @@ public:
         int get_resampler_initial_bps();
         size_t get_resampler_channel_count();
         bool resampler_is_set();
+        bool create_resampler(uint32_t original_sample_rate, uint32_t new_sample_rate_num, uint32_t new_sample_rate_den, size_t channel_size, int bps);
         void resample_set_destroy_flag(bool destroy);
 private:
         void *resampler{nullptr}; // type is (SpeexResamplerState *)
@@ -141,6 +142,7 @@ private:
         int resample_initial_bps{0};
         size_t resample_ch_count{0};
         bool destroy_resampler{false};
+        bool initial{}; 
 
         friend class audio_frame2;
 };

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -182,9 +182,11 @@ public:
         bool has_same_prop_as(audio_frame2 const &frame) const;
         void set_duration(double duration);
         void set_fec_params(int channel, fec_desc const &);
-        void check_data(const char* location, int i, bool flag);
         static audio_frame2 copy_with_bps_change(audio_frame2 const &frame, int new_bps);
         void change_bps(int new_bps);
+        void convert_int32_to_float();
+        void convert_float_to_int32();
+
         /**
          * @note
          * bps of the frame needs to be 16 bits!

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -127,6 +127,7 @@ public:
         int get_resampler_output_latency();
         int get_resampler_input_latency();
         int get_resampler_from_sample_rate();
+        int get_resampler_initial_bps();
         size_t get_resampler_channel_count();
         bool resampler_is_set();
         void resample_set_destroy_flag(bool destroy);
@@ -137,6 +138,7 @@ private:
         int resample_to_den{1};
         int resample_output_latency{0};
         int resample_input_latency{0};
+        int resample_initial_bps{0};
         size_t resample_ch_count{0};
         bool destroy_resampler{false};
 
@@ -207,6 +209,10 @@ private:
                 size_t max_len;
                 struct fec_desc fec_params;
         };
+        static void resample_channel(audio_frame2_resampler* resampler_state, int channel_index, 
+                                     const uint16_t *in, uint32_t in_len, channel *new_channel, audio_frame2 *remainder);
+        static void resample_channel(audio_frame2_resampler* resampler_state, int channel_index, 
+                                     const float *in, uint32_t in_len, channel *new_channel, audio_frame2 *remainder);
         void reserve(int channel, size_t len);
         int bps;                /* bytes per sample */
         int sample_rate;

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -182,7 +182,7 @@ public:
         bool has_same_prop_as(audio_frame2 const &frame) const;
         void set_duration(double duration);
         void set_fec_params(int channel, fec_desc const &);
-        void check_data(const char* location);
+        void check_data(const char* location, int i, bool flag);
         static audio_frame2 copy_with_bps_change(audio_frame2 const &frame, int new_bps);
         void change_bps(int new_bps);
         /**

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -211,8 +211,8 @@ private:
         };
         static void resample_channel(audio_frame2_resampler* resampler_state, int channel_index, 
                                      const uint16_t *in, uint32_t in_len, channel *new_channel, audio_frame2 *remainder);
-        static void resample_channel(audio_frame2_resampler* resampler_state, int channel_index, 
-                                     const float *in, uint32_t in_len, channel *new_channel, audio_frame2 *remainder);
+        static void resample_channel_float(audio_frame2_resampler* resampler_state, int channel_index, 
+                                           const float *in, uint32_t in_len, channel *new_channel, audio_frame2 *remainder);
         void reserve(int channel, size_t len);
         int bps;                /* bytes per sample */
         int sample_rate;

--- a/src/messaging.h
+++ b/src/messaging.h
@@ -38,6 +38,10 @@
 #ifndef _MESSAGING_H
 #define _MESSAGING_H
 
+#ifdef __cplusplus
+#include <cstring>
+#endif
+
 #include "types.h"
 
 #ifdef __cplusplus
@@ -152,6 +156,12 @@ struct msg_stats {
  * msg_universal::text to identify the receiving module.
  */
 struct msg_universal {
+#ifdef __cplusplus
+        msg_universal(const char *contents) {
+                memset(&m, 0, sizeof m);
+                strncpy(text, contents, sizeof text - 1);
+        }
+#endif
         struct message m;
         char text[8192];
 };

--- a/src/messaging.h
+++ b/src/messaging.h
@@ -61,6 +61,8 @@ struct response;
 #define RESPONSE_INT_SERV_ERR 500
 #define RESPONSE_NOT_IMPL     501
 
+#define RESPONSE_SUCCESSFUL(code) ((code) >= 200 && (code) < 300)
+
 struct message;
 
 struct message {

--- a/src/rtp/audio_decoders.cpp
+++ b/src/rtp/audio_decoders.cpp
@@ -763,89 +763,12 @@ int decode_audio_frame(struct coded_data *cdata, void *pbuf_data, struct pbuf_st
                 return FALSE;
         }
 
-        // If there is any audio leftover as part of the resample ensure that it's added to the beginning of the next audio frame
-        // regardless of whether or not there is more resampling to do.
-        if (decoder->resample_remainder) {
-                LOG(LOG_LEVEL_INFO) << MOD_NAME << " Adding the remainder to the audio\n";
-                if(decoder->resample_remainder.get_bps() > decompressed.get_bps()) {
-                        decompressed.change_bps(decoder->resample_remainder.get_bps());
-                }
-                else if (decoder->resample_remainder.get_bps() < decompressed.get_bps()){
-                        decoder->resample_remainder.change_bps(decompressed.get_bps());
-                }
-                decoder->resample_remainder.append(decompressed);
-                decompressed = move(decoder->resample_remainder);
-                decoder->resample_remainder = audio_frame2();
-        }
-
-        // Get the resample numerator and denominator out of the req_resample_to (this may be zero)
-        int resample_numerator = decoder->req_resample_to >> ADEC_CH_RATE_SHIFT;
-        int resample_denominator = decoder->req_resample_to & ((1LU << ADEC_CH_RATE_SHIFT) - 1);
-
-        // Here we want to check to see if the sample rate is being changed and if there is a resampler currently active.
-        // If this is true (so either we're changing to a new resample rate, or changing from a resample to the "normal" resample rate)
-        // then we need to drain the resampler of buffer it is holding still leftover from the resample delay. We can do this by feeding it
-        // as many zeroes as the size of the input latency from the resampler is.
-        if (decoder->req_resample_to != 0
-                        && decoder->resampler.resampler_is_set()
-                        && !decoder->resample_tail_buffer
-                        && (decompressed.get_sample_rate() != decoder->resampler.get_resampler_from_sample_rate()
-                                || resample_numerator != decoder->resampler.get_resampler_numerator()
-                                || resample_denominator != decoder->resampler.get_resampler_denominator()
-                                || (size_t)decompressed.get_channel_count() != decoder->resampler.get_resampler_channel_count()
-                                || decoder->resampler.get_resampler_initial_bps() != decompressed.get_bps())) {
-                LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " REMOVE removing tail buffer\n";
-                // The resampler is no longer required. Collect the remaining buffer from the resampler
-                audio_frame2 tail_buffer = audio_frame2();
-                tail_buffer.init(decompressed.get_channel_count(), decompressed.get_codec(), decoder->resampler.get_resampler_initial_bps(), decompressed.get_sample_rate());
-
-                // Generate a buffer the size of the input latency and apply it to all channels
-                uint32_t leftover_frames = (decoder->resampler.get_resampler_input_latency() - 1);
-                char buffer[leftover_frames * decoder->resampler.get_resampler_initial_bps()];
-                memset(buffer, 0, leftover_frames * decoder->resampler.get_resampler_initial_bps());
-                for(size_t i = 0; i < (size_t)tail_buffer.get_channel_count(); i++) {
-                        tail_buffer.append(i, buffer, leftover_frames * decoder->resampler.get_resampler_initial_bps());
-                }
-                // Extract remaining buffer from resampler by applying a resample the size of the input latency
-                tail_buffer.resample_fake(decoder->resampler, decoder->resampler.get_resampler_numerator(), decoder->resampler.get_resampler_denominator());
-
-                // If there was a resampling of size 32 bit then convert the floating point numbers into int32.
-                if(tail_buffer.get_bps() == 4) {
-                        tail_buffer.convert_float_to_int32();
-                }
-
-                // Check that the BPS of the tail buffer matches the decompressed (and if not, convert one to the other by upscaling)
-                if(tail_buffer.get_bps() > decompressed.get_bps()) {
-                        decompressed.change_bps(tail_buffer.get_bps());
-                }
-                else if (tail_buffer.get_bps() < decompressed.get_bps()){
-                        tail_buffer.change_bps(decompressed.get_bps());
-                }
-
-                // Append the decompressed audio to the buffer we have extracted
-                tail_buffer.append(decompressed);
-                decompressed = move(tail_buffer);
-                // Set the flag that ensures this is only run once when the change in sample rate occurs (as changing to the "original" resample rate
-                // will not destroy the resampler)
-                decoder->resample_tail_buffer = true;
-                // Ensure that this resampler can't be reused after draining it. This will force the destruction of the resampler on the next resample.
-                // This means that even if we switch to the original resample rate, and then back to the sample rate this resampler is set to then the
-                // resampler will be destroyed (as it will have a set of zeroes in it's buffer the size of the input latency).
-                decoder->resampler.resample_set_destroy_flag(true);
-        }
-
-        if (decoder->req_resample_to != 0 || s->buffer.sample_rate != decompressed.get_sample_rate()) {
-                // If the input is 32 bits big assume we're using int32 (rather than float). Convert from that to float
-                // as speex only has support for floating point resampling (and not int32). Then there is a requirement
-                // to convert back afterwards.
-                if(decompressed.get_bps() == 4) {
-                        decompressed.convert_int32_to_float();
-                }
-                // The main support BPS for the speex resampling is 2. So if the bytes per sample is not 4 or 2, convert
-                // to a bytes per sample that is best supported (4 bytes per sample is likely more accurate, but the 
-                // conversion from int32 to float and back to int32 losses some accuracy when rounding).
-                else if(decompressed.get_bps() != 2) {
-                        decompressed.change_bps(2);
+        // Perform a variable rate resample if any output device has requested it
+        if (decoder->req_resample_to != 0) {
+                // Set the BPS of the audio to be within the supported range. A value of 4 bytes has
+                // been selected as it'll give a higher accuracy for conversion.
+                if(decompressed.get_bps() != 2 || decompressed.get_bps() != 4) {
+                        decompressed.change_bps(4);
                 }
                 if (decoder->req_resample_to != 0) {
                         auto [ret, reinitResampler, remainder] = decompressed.resample_fake(decoder->resampler, decoder->req_resample_to >> ADEC_CH_RATE_SHIFT, decoder->req_resample_to & ((1LU << ADEC_CH_RATE_SHIFT) - 1));
@@ -854,29 +777,13 @@ int decode_audio_frame(struct coded_data *cdata, void *pbuf_data, struct pbuf_st
                                 return FALSE;
                         }
                         decoder->resample_remainder = move(remainder);
-                        // throw std::runtime_error("Close!");
-                        // If the resampler was destroyed and reinitialised then there will be a new buffer 
-                        // stored in the resampler we will need to extract later
-                        if(reinitResampler) {
-                                decoder->resample_tail_buffer = false;
-                        }
-                } else {
+                }
+                else {
                         auto [ret, reinitResampler] = decompressed.resample(decoder->resampler, s->buffer.sample_rate);
                         if (!ret) {
                                 LOG(LOG_LEVEL_INFO) << MOD_NAME << "You may try to set different sampling on sender.\n";
                                 return FALSE;
                         }
-                        
-                        // If the resampler was destroyed and reinitialised then there will be a new buffer 
-                        // stored in the resampler we will need to extract later
-                        if(reinitResampler) {
-                                decoder->resample_tail_buffer = false;
-                        }
-                }
-                // Now that resampling has occurred ensure that if there was a conversion from int32 to float that
-                // this is now reversed.
-                if(decompressed.get_bps() == 4) {
-                        decompressed.convert_float_to_int32();
                 }
         }
 

--- a/src/rtp/audio_decoders.cpp
+++ b/src/rtp/audio_decoders.cpp
@@ -766,18 +766,16 @@ int decode_audio_frame(struct coded_data *cdata, void *pbuf_data, struct pbuf_st
         // If there is any audio leftover as part of the resample ensure that it's added to the beginning of the next audio frame
         // regardless of whether or not there is more resampling to do.
         if (decoder->resample_remainder) {
+                LOG(LOG_LEVEL_INFO) << MOD_NAME << " Adding the remainder to the audio\n";
                 if(decoder->resample_remainder.get_bps() > decompressed.get_bps()) {
-                        LOG(LOG_LEVEL_INFO) << MOD_NAME << " BPSCHANGE " << decoder->resample_remainder.get_bps() << " remainderBps " << decompressed.get_bps() << " decompressedBps" << "\n";
                         decompressed.change_bps(decoder->resample_remainder.get_bps());
                 }
                 else if (decoder->resample_remainder.get_bps() < decompressed.get_bps()){
-                        LOG(LOG_LEVEL_INFO) << MOD_NAME << " BPSCHANGE " << decoder->resample_remainder.get_bps() << " remainderBps " << decompressed.get_bps() << " decompressedBps" << "\n";
                         decoder->resample_remainder.change_bps(decompressed.get_bps());
                 }
                 decoder->resample_remainder.append(decompressed);
                 decompressed = move(decoder->resample_remainder);
                 decoder->resample_remainder = audio_frame2();
-                LOG(LOG_LEVEL_INFO) << MOD_NAME << " Adding the remainder to the audio\n";
         }
 
         // Get the resample numerator and denominator out of the req_resample_to (this may be zero)

--- a/src/rtp/audio_decoders.cpp
+++ b/src/rtp/audio_decoders.cpp
@@ -803,15 +803,12 @@ int decode_audio_frame(struct coded_data *cdata, void *pbuf_data, struct pbuf_st
                         decompressed.change_bps(2);
                 }
                 if (decoder->req_resample_to != 0) {
-                        decompressed.check_data("PRE-SAMPLE");
                         auto [ret, reinitResampler, remainder] = decompressed.resample_fake(decoder->resampler, decoder->req_resample_to >> ADEC_CH_RATE_SHIFT, decoder->req_resample_to & ((1LU << ADEC_CH_RATE_SHIFT) - 1));
                         if (!ret) {
                                 LOG(LOG_LEVEL_INFO) << MOD_NAME << "You may try to set different sampling on sender.\n";
                                 return FALSE;
                         }
-                        decompressed.check_data("POST-SAMPLE");
                         decoder->resample_remainder = move(remainder);
-                        decompressed.check_data("POST-REMAIN");
 
                         if(reinitResampler) {
                                 decoder->resampleTailBuffer = false;

--- a/src/rtp/audio_decoders.cpp
+++ b/src/rtp/audio_decoders.cpp
@@ -786,7 +786,7 @@ int decode_audio_frame(struct coded_data *cdata, void *pbuf_data, struct pbuf_st
                         && (decompressed.get_sample_rate() != decoder->resampler.get_resampler_from_sample_rate()
                                 || resample_numerator != decoder->resampler.get_resampler_numerator()
                                 || resample_denominator != decoder->resampler.get_resampler_denominator()
-                                || decompressed.get_channel_count() != decoder->resampler.get_resampler_channel_count())) {
+                                || (size_t)decompressed.get_channel_count() != decoder->resampler.get_resampler_channel_count())) {
                 // The resampler is no longer required. Collect the remaining buffer from the resampler
                 audio_frame2 tailBuffer = audio_frame2();
                 tailBuffer.init(decompressed.get_channel_count(), decompressed.get_codec(), decompressed.get_bps(), decompressed.get_sample_rate());
@@ -794,7 +794,7 @@ int decode_audio_frame(struct coded_data *cdata, void *pbuf_data, struct pbuf_st
                 // Generate a buffer the size of the input latency and apply it to all channels
                 char buffer[(decoder->resampler.get_resampler_input_latency()) * sizeof(uint16_t)];
                 memset(buffer, 0, sizeof(buffer));
-                for(size_t i = 0; i < tailBuffer.get_channel_count(); i++) {
+                for(size_t i = 0; i < (size_t)tailBuffer.get_channel_count(); i++) {
                         tailBuffer.append(i, buffer, decoder->resampler.get_resampler_input_latency()  * sizeof(uint16_t));
                 }
                 // Extract remaining buffer from resampler by applying a resample the size of the input latency

--- a/src/rtp/audio_decoders.cpp
+++ b/src/rtp/audio_decoders.cpp
@@ -273,6 +273,9 @@ static void audio_decoder_process_message(struct module *m)
         }
 }
 
+ADD_TO_PARAM("soft-resample", "* soft-resample=<num>/<den>\n"
+                "  Resample to specified sampling rate, eg. 12288128/256 for 48000.5 Hz\n");
+
 void *audio_decoder_init(char *audio_channel_map, const char *audio_scale, const char *encryption, audio_playback_ctl_t c, void *p_state, struct module *parent)
 {
         struct state_audio_decoder *s;
@@ -292,6 +295,11 @@ void *audio_decoder_init(char *audio_channel_map, const char *audio_scale, const
         s->mod.priv_data = s;
         s->mod.new_message = audio_decoder_process_message;
         module_register(&s->mod, parent);
+
+        if (const char *val = get_commandline_param("soft-resample")) {
+                assert(strchr(val, '/') != nullptr);
+                s->req_resample_to = atol(val) << 32LLU | atol(strchr(val, '/') + 1);
+        }
 
         gettimeofday(&s->t0, NULL);
         s->packet_counter = packet_counter_init(0);

--- a/src/rtp/audio_decoders.h
+++ b/src/rtp/audio_decoders.h
@@ -54,6 +54,9 @@ void audio_decoder_set_volume(void *state, double val);
 
 bool parse_audio_hdr(uint32_t *hdr, struct audio_desc *desc);
 
+#define MSG_UNIVERSAL_TAG_AUDIO_DECODER "ADEC "
+#define ADEC_CH_RATE_SHIFT 32LU
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/video_capture/decklink.cpp
+++ b/src/video_capture/decklink.cpp
@@ -1215,6 +1215,7 @@ vidcap_decklink_init(struct vidcap_params *params, void **state)
 
                 BMD_CONFIG_SET_INT(bmdDeckLinkConfigVideoInputConnection, s->connection);
                 BMD_CONFIG_SET_INT(bmdDeckLinkConfigVideoInputConversionMode, s->conversion_mode);
+                BMDVideoInputConversionMode supported_conversion_mode = s->conversion_mode ? s->conversion_mode : (BMDVideoInputConversionMode) bmdNoVideoInputConversion;
                 BMD_CONFIG_SET_INT(bmdDeckLinkConfigCapturePassThroughMode, s->passthrough);
 
                 if (s->link == 0) {
@@ -1281,7 +1282,7 @@ vidcap_decklink_init(struct vidcap_params *params, void **state)
                                 }
                                 BMDPixelFormat pf = it->second;
                                 BMD_BOOL supported = 0;
-                                EXIT_IF_FAILED(deckLinkInput->DoesSupportVideoMode(s->connection, displayMode->GetDisplayMode(), pf, s->conversion_mode, s->supported_flags, nullptr, &supported), "DoesSupportVideoMode");
+                                EXIT_IF_FAILED(deckLinkInput->DoesSupportVideoMode(s->connection, displayMode->GetDisplayMode(), pf, supported_conversion_mode, s->supported_flags, nullptr, &supported), "DoesSupportVideoMode");
                                 if (supported) {
                                         break;
                                 }
@@ -1343,7 +1344,7 @@ vidcap_decklink_init(struct vidcap_params *params, void **state)
                 }
 
                 BMD_BOOL supported = 0;
-                EXIT_IF_FAILED(deckLinkInput->DoesSupportVideoMode(s->connection, displayMode->GetDisplayMode(), pf, s->conversion_mode, s->supported_flags, nullptr, &supported), "DoesSupportVideoMode");
+                EXIT_IF_FAILED(deckLinkInput->DoesSupportVideoMode(s->connection, displayMode->GetDisplayMode(), pf, supported_conversion_mode, s->supported_flags, nullptr, &supported), "DoesSupportVideoMode");
 
                 if (!supported) {
                         LOG(LOG_LEVEL_ERROR) << MOD_NAME "Requested display mode not supported with the selected pixel format\n";

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -397,9 +397,9 @@ class DeckLink3DFrame : public DeckLinkFrame, public IDeckLinkVideoFrame3DExtens
  * - handle underruns
  * - what about jitter - while computing the dst sample rate, the sampling interval (m_total) must be "long"
  */
-class audio_drift_fixer {
+class AudioDriftFixer {
 public:
-        audio_drift_fixer(int buffer_samples, int delta_samples, 
+        AudioDriftFixer(int buffer_samples, int delta_samples, 
                           int target_buffer_fill = 0, int positive_jitter = 0,
                           int negative_jitter = 0) : average_buffer_samples(buffer_samples),average_delta(delta_samples),
                                                      target_buffer_fill(target_buffer_fill), pos_jitter(positive_jitter),
@@ -459,13 +459,13 @@ public:
                         // for different cards can be applied
                         // Check to see if we have a target amount of the buffer we'd like to fill
                         if(this->target_buffer_fill == 0) {
-                                this->target_buffer_fill =  audio_drift_fixer::TARGET_BUFFER_DEFAULT;
+                                this->target_buffer_fill =  AudioDriftFixer::TARGET_BUFFER_DEFAULT;
                         }
                         if(this->pos_jitter == 0) {                           
-                                this->pos_jitter = audio_drift_fixer::POS_JITTER_DEFAULT;
+                                this->pos_jitter = AudioDriftFixer::POS_JITTER_DEFAULT;
                         }
                         if(this->neg_jitter == 0) {
-                                this->neg_jitter = audio_drift_fixer::NEG_JITTER_DEFAULT;
+                                this->neg_jitter = AudioDriftFixer::NEG_JITTER_DEFAULT;
                         }
 
                         // Check whether there needs to be any resampling                        
@@ -530,9 +530,9 @@ private:
         uint32_t max_avg = 3650;
         uint32_t min_avg = 1800;
 
-        static uint32_t TARGET_BUFFER_DEFAULT = 3000;
-        static uint32_t POS_JITTER_DEFAULT = 600;
-        static uint32_t NEG_JITTER_DEFAULT = 600;
+        static const uint32_t TARGET_BUFFER_DEFAULT = 3000;
+        static const uint32_t POS_JITTER_DEFAULT = 600;
+        static const uint32_t NEG_JITTER_DEFAULT = 600;
 };
 
 
@@ -585,7 +585,7 @@ struct state_decklink {
 
         mutex               reconfiguration_lock; ///< for audio and video reconf to be mutually exclusive
 
-        audio_drift_fixer audio_drift_fixer;
+        AudioDriftFixer audio_drift_fixer{500, 150, 3000, 600, 600};
 
         uint32_t            last_buffered_samples;
         int32_t             drift_since_last_correction;
@@ -1363,7 +1363,6 @@ static void *display_decklink_init(struct module *parent, const char *fmt, unsig
         s->low_latency = true;
         s->last_buffered_samples = 0;
         s->drift_since_last_correction = 0;
-        s->audio_drift_fixer = audio_drift_fixer(500, 150, 3000, 600, 600);
 
         if (!settings_init(s, fmt, &cardId, &HDMI3DPacking, &audio_consumer_levels, &use1080psf)) {
                 delete s;

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -798,7 +798,7 @@ struct state_decklink {
 
         mutex               reconfiguration_lock; ///< for audio and video reconf to be mutually exclusive
 
-        AudioDriftFixer audio_drift_fixer{250, 25, 2700, 50, 50};
+        AudioDriftFixer audio_drift_fixer{250, 25, 2700, 600, 600};
 
         uint32_t            last_buffered_samples;
         int32_t             drift_since_last_correction;

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -399,7 +399,7 @@ class DeckLink3DFrame : public DeckLinkFrame, public IDeckLinkVideoFrame3DExtens
  */
 class deck_audio_drift_fixer {
 public:
-        deck_audio_drift_fixer() : average_buffer_samples(100),average_delta(150){}
+        deck_audio_drift_fixer() : average_buffer_samples(500),average_delta(150){}
 
         bool m_enabled = false;
 
@@ -458,24 +458,22 @@ public:
                         if( target_buffer_fill == 0) {
                                 // @todo - Have a more dynamic approach to stabalising the buffer during clock drift.
                                 target_buffer_fill =  3000;                                
-                                // this->posJitter = 600;
-                                // this->negJitter = 600;
-                                this->posJitter = 5;
-                                this->negJitter = 5;
+                                this->posJitter = 600;
+                                this->negJitter = 600;
+                                // this->posJitter = 5;
+                                // this->negJitter = 5;
                         }
 
                         // Check whether there needs to be any resampling                        
                         if (average_buffer_depth  > target_buffer_fill + this->posJitter)
                         {
                                 // The buffer is too large, so we need to resample down to remove some frames
-                                // int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
-                                int resampleHz = 5;
+                                int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
                                 dst_frame_rate = (bmdAudioSampleRate48kHz - resampleHz) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed fast " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
                         } else if(average_buffer_depth < target_buffer_fill - this->negJitter) {
                                  // The buffer is too small, so we need to resample up to generate some additional frames
-                                // int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
-                                int resampleHz = 5;
+                                int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
                                 dst_frame_rate = (bmdAudioSampleRate48kHz + resampleHz) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed slow " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
                         } else {

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -451,17 +451,12 @@ public:
 
                 // Check to see if our buffered samples has enough to calculate a good average
                 if (average_buffer_samples.filled()) {
-                        // Calculate the average
-                        // uint32_t average_buffer_depth = (uint32_t)average_buffer_samples.avg();
-
                         // Check to see if we have a target amount of the buffer we'd like to fill
                         if( target_buffer_fill == 0) {
                                 // @todo - Have a more dynamic approach to stabalising the buffer during clock drift.
                                 target_buffer_fill =  3000;                                
                                 this->posJitter = 600;
                                 this->negJitter = 600;
-                                // this->posJitter = 5;
-                                // this->negJitter = 5;
                         }
 
                         // Check whether there needs to be any resampling                        
@@ -470,12 +465,12 @@ public:
                                 // The buffer is too large, so we need to resample down to remove some frames
                                 int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
                                 dst_frame_rate = (bmdAudioSampleRate48kHz - resampleHz) * BASE;
-                                LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed fast " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
+                                LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed slow " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
                         } else if(average_buffer_depth < target_buffer_fill - this->negJitter) {
                                  // The buffer is too small, so we need to resample up to generate some additional frames
                                 int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
                                 dst_frame_rate = (bmdAudioSampleRate48kHz + resampleHz) * BASE;
-                                LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed slow " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
+                                LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed fast " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
                         } else {
                                 // If there is nothing to do, then set the resample rate to be the base resample rate.
                                 // This is needed because otherwise code elsewhere may not recognise that there should
@@ -485,7 +480,7 @@ public:
                         }       
                 }
 
-                LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE2 " <<  average_buffer_depth << " vs " << buffered_count << " " << dst_frame_rate << " dst_frame_rate "<<"\n";
+                LOG(LOG_LEVEL_DEBUG) << MOD_NAME << " UPDATE2 " <<  average_buffer_depth << " vs " << buffered_count << " " << dst_frame_rate << " dst_frame_rate "<<"\n";
 
    
                 if (dst_frame_rate != 0) {

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -1558,7 +1558,7 @@ static bool settings_init(struct state_decklink *s, const char *fmt,
                                 }
                         }
                 } else if (strstr(ptr, "no_drift_fix") == ptr) {
-                        s->audio_drift_fixer.m_enabled = true;
+                        s->audio_drift_fixer.m_enabled = false;
                 }
                 else if (strncasecmp(ptr, "maxresample=", strlen("maxresample=")) == 0) {
                         uint32_t max_resample_delta = 0;

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -55,7 +55,10 @@
 #include "debug.h"
 #include "host.h"
 #include "lib_common.h"
+#include "messaging.h"
+#include "module.h"
 #include "rang.hpp"
+#include "rtp/audio_decoders.h"
 #include "tv.h"
 #include "ug_runtime_error.hpp"
 #include "utils/misc.h"
@@ -64,6 +67,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cinttypes>
 #include <cstdint>
@@ -72,7 +76,6 @@
 #include <queue>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #include "DeckLinkAPIVersion.h"
 
@@ -308,6 +311,96 @@ class DeckLink3DFrame : public DeckLinkFrame, public IDeckLinkVideoFrame3DExtens
 };
 } // end of unnamed namespace
 
+/**
+ * @todo
+ * - handle network losses
+ * - handle underruns
+ * - what about jitter - while computing the dst sample rate, the sampling interval (m_total) must be "long"
+ */
+class deck_audio_drift_fixer {
+public:
+        bool m_enabled = false;
+
+        void set_root(module *root) {
+                m_root = root;
+        }
+        void set_fps(double fps) {
+                m_new_fps = fps; // schedule for reinit
+        }
+        /// @retval flag if the audio frame should be written
+        bool update(int buffered_count, int to_be_written) {
+                if (!m_enabled) {
+                        return true;
+                }
+                if (m_new_fps != m_fps) {
+                        m_fps = m_new_fps;
+                        if (!reinit(buffered_count, to_be_written)) {
+                                return false;
+                        }
+                }
+                if (m_fps == 0) { // not initialized
+                        return true;
+                }
+                m_total += to_be_written;
+
+                long long dst_frame_rate = 0;
+                if (m_resample_level < 0 && buffered_count + to_be_written < per_frame_samples) {
+                        dst_frame_rate = bmdAudioSampleRate48kHz * BASE;
+                        m_resample_level = 0;
+                } else if (m_resample_level == 0 && buffered_count + to_be_written > per_frame_samples * soft_buf_ratio_pct / 100) {
+                        // computed in shifted base by 256
+                        long long drift_samples = ((buffered_count + to_be_written) - m_buffered0) * BASE * bmdAudioSampleRate48kHz / m_total;
+                        dst_frame_rate = BASE * bmdAudioSampleRate48kHz - drift_samples;
+                        m_resample_level = -1;
+                } else if (m_resample_level == -1 && buffered_count + to_be_written > per_frame_samples * hard_buf_ratio_pct / 100) {
+                        long long drift_samples = ((buffered_count + to_be_written) - m_buffered0) * BASE * bmdAudioSampleRate48kHz / m_total;
+                        dst_frame_rate = (BASE * bmdAudioSampleRate48kHz - drift_samples) + 128; // slightly 1/2/48000 faster frame rate than computed
+                        m_resample_level = -2;
+                }
+
+                if (dst_frame_rate != 0) {
+                        auto *m = new msg_universal((string(MSG_UNIVERSAL_TAG_AUDIO_DECODER) + to_string(dst_frame_rate << ADEC_CH_RATE_SHIFT | BASE)).c_str());
+                        LOG(LOG_LEVEL_VERBOSE) << MOD_NAME "Sending resample request " << m_resample_level << ": " << dst_frame_rate << "/" << BASE << "\n";
+                        assert(m_root != nullptr);
+                        auto *response = send_message_sync(m_root, "audio.receiver.decoder", reinterpret_cast<message *>(m), 100, SEND_MESSAGE_FLAG_NO_STORE);
+                        if (!RESPONSE_SUCCESSFUL(response_get_status(response))) {
+                                LOG(LOG_LEVEL_WARNING) << MOD_NAME "Unable to send resample message: " << response_get_text(response) << " (" << response_get_status(response) << ")\n";
+                        }
+                        free_response(response);
+                }
+
+                return true;
+        }
+
+private:
+        static constexpr unsigned long BASE = (1U<<8U);
+        bool reinit(int buffered_count, int to_be_written) {
+                m_total = 0;
+                per_frame_samples = bmdAudioSampleRate48kHz / m_fps;
+                m_resample_level = 0;
+                if (buffered_count + to_be_written > per_frame_samples * max_init_buf_ratio_pct / 100) {
+                        m_buffered0 = buffered_count;
+                        return false;
+                }
+                m_buffered0 = buffered_count + to_be_written;
+                return true;
+        }
+
+        struct module *m_root = nullptr;
+
+        atomic<double> m_new_fps{0.0};
+        double m_fps{0.0};
+        long per_frame_samples{0};
+        int m_buffered0{0}; ///< initial buffer filling
+        long long m_total{};
+        int m_resample_level = 0; // <0 downsampling, 0 none
+
+        /// DeckLink buffers 3 frames of sound
+        constexpr static int soft_buf_ratio_pct = 250;
+        constexpr static int hard_buf_ratio_pct = 280;
+        constexpr static int max_init_buf_ratio_pct = 180;
+};
+
 #define DECKLINK_MAGIC 0x12de326b
 
 struct device_state {
@@ -356,6 +449,8 @@ struct state_decklink {
         bool                low_latency       = true;
 
         mutex               reconfiguration_lock; ///< for audio and video reconf to be mutually exclusive
+
+        deck_audio_drift_fixer audio_drift_fixer;
  };
 
 static void show_help(bool full);
@@ -715,6 +810,7 @@ display_decklink_reconfigure_video(void *state, struct video_desc desc)
         HRESULT                           result;
 
         unique_lock<mutex> lk(s->reconfiguration_lock);
+        s->audio_drift_fixer.set_fps(desc.fps);
 
         assert(s->magic == DECKLINK_MAGIC);
         
@@ -1036,6 +1132,8 @@ static bool settings_init(struct state_decklink *s, const char *fmt,
                                         return false;
                                 }
                         }
+                } else if (strstr(ptr, "drift_fix") == ptr) {
+                        s->audio_drift_fixer.m_enabled = true;
                 } else {
                         log_msg(LOG_LEVEL_ERROR, MOD_NAME "Warning: unknown options in config string.\n");
                         return false;
@@ -1058,7 +1156,6 @@ static bool settings_init(struct state_decklink *s, const char *fmt,
 
 static void *display_decklink_init(struct module *parent, const char *fmt, unsigned int flags)
 {
-        UNUSED(parent);
         IDeckLinkIterator*                              deckLinkIterator;
         HRESULT                                         result;
         vector<string>                                  cardId;
@@ -1080,6 +1177,7 @@ static void *display_decklink_init(struct module *parent, const char *fmt, unsig
         }
 
         auto *s = new state_decklink();
+        s->audio_drift_fixer.set_root(get_root_module(parent));
 
         if (!settings_init(s, fmt, &cardId, &HDMI3DPacking, &audio_consumer_levels, &use1080psf)) {
                 delete s;
@@ -1505,6 +1603,9 @@ static void display_decklink_put_audio_frame(void *state, struct audio_frame *fr
         s->state[0].deckLinkOutput->GetBufferedAudioSampleFrameCount(&buffered);
         if (buffered == 0) {
                 LOG(LOG_LEVEL_WARNING) << MOD_NAME << "audio buffer underflow!\n";
+        }
+        if (!s->audio_drift_fixer.update(buffered, sampleFrameCount)) {
+                return;
         }
 
         if (s->low_latency) {

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -472,7 +472,7 @@ public:
                 }
                 // Check to see if the amount in the buffer has dropped by over half the average
                 // number of samples being written. If so, we likely dropped a frame.
-                if(this->prev_buffer_samples > buffer_samples + (samples / 2)) {
+                if(prev_buffer_samples >= 0 && (uint32_t)this->prev_buffer_samples > buffer_samples + (samples / 2)) {
                         this->frames_missed++;
                 }
                 this->prev_buffer_samples = buffer_samples;

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -427,7 +427,7 @@ public:
 
                 const uint32_t AUDIO_BUFFER_MAX = 4096; // MAX buffered audio sample in blackmagic
                 //uint32_t target_buffer_fill = AUDIO_BUFFER_MAX / 3 * 2;
-                uint32_t jitter = 5;
+                uint32_t jitter = 50;
 
                 average_buffer_samples.add((double)buffered_count);
                 int frameJitter = buffered_count - previous_buffer;

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -472,12 +472,12 @@ public:
                         if (average_buffer_depth  > target_buffer_fill + this->pos_jitter)
                         {
                                 // The buffer is too large, so we need to resample down to remove some frames
-                                int resample_hz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
+                                int resample_hz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill + this->pos_jitter);
                                 dst_frame_rate = (bmdAudioSampleRate48kHz - resample_hz) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed slow " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
                         } else if(average_buffer_depth < target_buffer_fill - this->neg_jitter) {
                                  // The buffer is too small, so we need to resample up to generate some additional frames
-                                int resample_hz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
+                                int resample_hz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill - this->neg_jitter);
                                 dst_frame_rate = (bmdAudioSampleRate48kHz + resample_hz) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed fast " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
                         } else {
@@ -517,8 +517,8 @@ private:
         uint32_t previous_buffer = 0;
 
         // The min and max Hz changes we can resample between
-        uint32_t min_hz = 5;
-        uint32_t max_hz = 50;
+        uint32_t min_hz = 1;
+        uint32_t max_hz = 5;
         // The min and max values to scale between
         uint32_t min_buffer = 100;
         uint32_t max_buffer = 600;
@@ -585,7 +585,7 @@ struct state_decklink {
 
         mutex               reconfiguration_lock; ///< for audio and video reconf to be mutually exclusive
 
-        AudioDriftFixer audio_drift_fixer{500, 150, 3000, 600, 600};
+        AudioDriftFixer audio_drift_fixer{250, 150, 2700, 600, 600};
 
         uint32_t            last_buffered_samples;
         int32_t             drift_since_last_correction;

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -517,22 +517,47 @@ public:
 
         bool m_enabled = true;
 
+        /**
+         * @brief Set the max hz object
+         * 
+         * @param max_hz The maximum hz delta that can be applied to fix the drift
+         */
         void set_max_hz(uint32_t max_hz) {
                 this->max_hz = max_hz;
         }
 
+        /**
+         * @brief Set the min hz object
+         * 
+         * @param min_hz The minimum hz delta that can be applied to fix the drift
+         */
         void set_min_hz(uint32_t min_hz) {
                 this->min_hz = min_hz;
         }
 
+        /**
+         * @brief Set the target buffer object
+         * 
+         * @param target_buffer The target buffer of samples per channel
+         */
         void set_target_buffer(uint32_t target_buffer) {
                 this->target_buffer_fill = target_buffer;
         }
 
+        /**
+         * @brief Set the summary object
+         * 
+         * @param audio_summary The audio summary pointer
+         */
         void set_summary(DecklinkAudioSummary *audio_summary) {
                 this->audio_summary = audio_summary;
         }
 
+        /**
+         * @brief Set the root object
+         * 
+         * @param root The root module
+         */
         void set_root(module *root) {
                 m_root = root;
         }
@@ -1306,6 +1331,16 @@ static void display_decklink_probe(struct device_info **available_cards, int *co
 }
 
 
+/**
+ * @brief A helper function for parsing unsigned integers out of the command line parameters. This will not allow negative numbers
+ *        or numbers that are longer than 9 digits long (this stops undefined behaviour occuring). Any error case should apply a
+ *        default value.
+ * 
+ * @param value_str    The string that is being parsed.
+ * @param value_name   The name of the parameter that is being parsed
+ * @param value          A pointer to a uint32 to write the parsed value into
+ * @param default_value  The default value that should be applied in any of the error cases.
+ */
 static void parse_uint32(const char *value_str, const char *value_name, uint32_t *value, uint32_t default_value) {
         int value_len = strlen(value_str);
         if(value_len == 0) {
@@ -1320,7 +1355,7 @@ static void parse_uint32(const char *value_str, const char *value_name, uint32_t
         }
         int tmp_value = atoi(value_str);
         if(tmp_value < 1) {
-                LOG(LOG_LEVEL_ERROR) << MOD_NAME << "Inputted resample string negative number - " << value_name << " - Setting to default " << default_value << "\n";
+                LOG(LOG_LEVEL_ERROR) << MOD_NAME << "Inputted resample string negative number or not a valid number - " << value_name << " - Setting to default " << default_value << "\n";
                 *value = default_value;
         }
         else {

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -403,7 +403,7 @@ public:
          */
         void report() {
                 std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-                if(std::chrono::duration_cast<std::chrono::seconds>(now - this->last_summary).count() > 30) {
+                if(std::chrono::duration_cast<std::chrono::seconds>(now - this->last_summary).count() > 10) {
                 
                         LOG(LOG_LEVEL_INFO) << rang::style::underline << "Decklink stats (cumulative)" 
                                         << rang::style::reset     << " - Total Audio Frames Played: "

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -453,24 +453,13 @@ public:
                 int32_t delta = (int32_t)average_buffer_depth - (int32_t) buffered_count;
                 if (average_buffer_samples.filled()) {
                         if( target_buffer_fill == 0) {
-                                if(average_buffer_depth > this->maxAvg) {
-                                        target_buffer_fill = this->maxAvg - 500;
-                                }
-                                else if(average_buffer_depth < this->minAvg) {
-                                        target_buffer_fill = this->minAvg + 500;
-                                }
-                                else {
-                                        target_buffer_fill = average_buffer_depth;
-                                }
-                                
-                                // this->posJitter = this->maxAvg - target_buffer_fill;
-                                // this->negJitter =  target_buffer_fill - this->minAvg;
-                                this->posJitter = 5;
-                                this->negJitter = 5;
+                                target_buffer_fill =  3000;                                
+                                this->posJitter = 600;
+                                this->negJitter =  600;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE target "<< target_buffer_fill << " posJitter " << this->posJitter << " negJitter " << this->negJitter << " \n";
                         }
 
-                        /*
+                        
                         if (average_buffer_depth  > target_buffer_fill + this->posJitter)
                         {
                                 // buffered samples to big shrink
@@ -485,16 +474,16 @@ public:
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed slow " <<  average_buffer_depth << " vs " << buffered_count << " " << delta << " delta " << average_delta.getTotal() << " average_velocity " <<  frameJitter << " jitter " << resampleHz << " resampleHz\n";
                         } else {
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed normal " <<  average_buffer_depth << " vs " << buffered_count << " " << delta << " delta " << average_delta.getTotal() << " average_velocity " <<  frameJitter << " jitter 0 resampleHz\n";
-                                // dst_frame_rate = bmdAudioSampleRate48kHz * BASE * 1;
+                                dst_frame_rate = bmdAudioSampleRate48kHz * BASE;
                         }
-                        */
 
+                        /*
                         if(counter  == 20 || counter == 25 || counter == 40 || counter == 50) {
-                                dst_frame_rate = (bmdAudioSampleRate48kHz - 100) * BASE;
+                                dst_frame_rate = (bmdAudioSampleRate48kHz + 50) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " CHANGE resample 100" << "\n";
                         }
                         else if ( counter  == 30 || counter == 35 || counter == 45 || counter == 55) {
-                                dst_frame_rate = (bmdAudioSampleRate48kHz - 150) * BASE;
+                                dst_frame_rate = (bmdAudioSampleRate48kHz - 50) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " CHANGE resample 150" << "\n";
                         }
                         else {
@@ -502,6 +491,7 @@ public:
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " CHANGE resample same" << "\n";
                         }
 			counter++;
+                        */
                        
                         
                        /*
@@ -597,8 +587,8 @@ private:
         // Calculate the jitter so that we're within an acceptable range
         uint32_t posJitter = 0;
         uint32_t negJitter = 0;
-        uint32_t maxAvg = 3750;
-        uint32_t minAvg = 1500;
+        uint32_t maxAvg = 3650;
+        uint32_t minAvg = 1800;
 
         uint32_t counter = 0;
 

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -468,12 +468,14 @@ public:
                         if (average_buffer_depth  > target_buffer_fill + this->posJitter)
                         {
                                 // The buffer is too large, so we need to resample down to remove some frames
-                                int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
+                                // int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
+                                int resampleHz = 5;
                                 dst_frame_rate = (bmdAudioSampleRate48kHz - resampleHz) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed fast " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
                         } else if(average_buffer_depth < target_buffer_fill - this->negJitter) {
                                  // The buffer is too small, so we need to resample up to generate some additional frames
-                                int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
+                                // int resampleHz = (int)this->scale_buffer_delta(average_buffer_depth - target_buffer_fill);
+                                int resampleHz = 5;
                                 dst_frame_rate = (bmdAudioSampleRate48kHz + resampleHz) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed slow " <<  average_buffer_depth << " vs " << buffered_count << " " << average_delta.getTotal() << " average_velocity \n";
                         } else {

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -513,7 +513,7 @@ public:
                 if(this->prev_audio_end.time_since_epoch().count() != 0) {
                         // Collect the time now and do a comparison to the time when we ended the previous function call
                         std::chrono::high_resolution_clock::time_point audio_begin = std::chrono::high_resolution_clock::now();
-                        std::chrono::milliseconds time_diff = std::chrono::duration_cast<std::chrono::milliseconds>(this->prev_audio_end - audio_begin);
+                        std::chrono::milliseconds time_diff = std::chrono::duration_cast<std::chrono::milliseconds>(audio_begin - this->prev_audio_end);
 
                         // Set a max or min if the timing is outside of whats already been collected
                         long long duration_diff = time_diff.count();

--- a/src/video_display/decklink.cpp
+++ b/src/video_display/decklink.cpp
@@ -447,11 +447,11 @@ public:
                         if (average_buffer_depth  > target_buffer_fill + jitter  )
                         {
                                 // buffered samples to big shrink
-                                dst_frame_rate = (bmdAudioSampleRate48kHz * BASE) - 5;
+                                dst_frame_rate = (bmdAudioSampleRate48kHz - 5) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed fast " <<  average_buffer_depth << " vs " << buffered_count << " " << delta << " delta " << average_delta.getTotal() << " average_velocity " <<  frameJitter << " jitter\n";
                         } else if(average_buffer_depth < target_buffer_fill - jitter ) {
                                  // buffer is increasing as we are not playing slower than the source
-                                dst_frame_rate = (bmdAudioSampleRate48kHz * BASE) + 5;
+                                dst_frame_rate = (bmdAudioSampleRate48kHz + 5) * BASE;
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed slow " <<  average_buffer_depth << " vs " << buffered_count << " " << delta << " delta " << average_delta.getTotal() << " average_velocity " <<  frameJitter << " jitter\n";
                         } else {
                                 LOG(LOG_LEVEL_VERBOSE) << MOD_NAME << " UPDATE playing speed normal " <<  average_buffer_depth << " vs " << buffered_count << " " << delta << " delta " << average_delta.getTotal() << " average_velocity " <<  frameJitter << " jitter\n";


### PR DESCRIPTION
Added a dynamic resampling method that will control the amount of samples in the buffer for Decklink cards so that any drift occurring that causes overflows or underflows can be avoided.

It's worth noting that while this fix works well for Decklink cards, for 32bit Audio support there is a conversion between 32Bit integers and floats so that the Speex float resampler can be used (before a conversion back). If not all cards produce 32Bit integer audio, then this will cause any resampling that happens with these cards to break.

In longer term testing this has produced desirable results, which removes any popping, or glitches in the audio.

The threaded performance improvements make it so that the highest quality resampling can be used with minimal impact. Threaded vs unthreaded for quality 10 gave an increase in performance of roughly 250% (across 16 channels of data).

**Fixed**
- Fixed resampler outputting the zero bytes it inserts at the beginning of the resample period.
- Fixed remainder audio being added back to the next audio frame regardless of whether or not resampling is occuring.

**Changed**
- Changed the 'drift_fix' option to be 'no_drift_fix' and for the drift fix for decklink cards to always be active.

**Added**
- Added scaling support for the deck drift audio fixer class. This will now scale the amount required to resample based on the distance between the target buffer and the average of the target buffer (within the last 10 seconds).
- Added threading for resampling across multiple channels (significant performance increase noted).
- Added support for 32bit Integer resampling (by conversion to 32bit Float).
- Added removal of the tail buffer of audio from the resampler when switching between different sample rates.
- Added new parameters for the decklink:
  - 'targetbuffer' - The target amount of samples to have in the buffer (per channel).
  - 'minresample' - The minimum amount the resample delta can be when scaling is applied. Measured in Hz.
  - 'maxresample' - The maximum amount the resample delta can be when scaling is applied. Measured in Hz.
- Added statistics for tracking a number of useful cumulative stats for the decklink card. Included is the amount of times requests for resampling have been committed, underflows, overflows, etc.
- Added new functions to the audio_frame2_resampler class for use when querying its state.