### PR TITLE
testcard2: add another default font for Linux

### DIFF
--- a/src/video_capture/testcard2.c
+++ b/src/video_capture/testcard2.c
@@ -88,8 +88,10 @@ static const char * const font_candidates[] = { "cour.ttf", };
 static const char * const font_candidates[] = { "Monaco.ttf", "Geneva.ttf", "Keyboard.ttf", };
 #else
 #define DEFAULT_FONT_DIR "/usr/share/fonts"
-static const char * const font_candidates[] = { "DejaVuSansMono.ttf", "truetype/freefont/FreeMonoBold.ttf", "truetype/DejaVuSansMono.ttf",
-        "TTF/DejaVuSansMono.ttf", "liberation/LiberationMono-Regular.ttf", }; // Arch
+static const char * const font_candidates[] = {
+        "DejaVuSansMono.ttf", "truetype/freefont/FreeMonoBold.ttf", "truetype/DejaVuSansMono.ttf","TTF/DejaVuSansMono.ttf", "liberation/LiberationMono-Regular.ttf", // Arch
+        "liberation-mono/LiberationMono-Regular.ttf", // Fedora
+}; 
 #endif
 #endif // defined HAVE_LIBSDL_TTF
 


### PR DESCRIPTION
None of the specified font paths exits on Fedora 36 Workstation.
The added font path exists in a default installation.