### PR TITLE
pixfmt_conv.c: RGB <-> RGBA

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,4 @@
-FLAGS ?= -O2 -g
+FLAGS ?= -O2 -g -msse4.1
 SRCDIR ?= ..
 COMMON_FLAGS = $(FLAGS) -D_GNU_SOURCE -I$(SRCDIR)/src/
 MKDIR_P = mkdir -p


### PR DESCRIPTION
This PR adds conversions between RGBA and RGB written in SIMD intrinsics, reducing time per 4k frame from 9 ms to about 5 ms.

This code specializes only for color shifts of the RGBx and BGRx formats, since allowing arbitrary channel shifts would complicate code unnecessarily and wouldn't be faster.