### PR TITLE
Fix spelling errors throughout codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to contribute to UltraGrid
 First, thanks to contribute to UltraGrid by using UltraGrid, reporting bugs,
-adding code or ideas. Further section contains basic informations how to
+adding code or ideas. Further section contains basic information how to
 contribute. Feel free to inform us if you need to contribute in a different
 way or extend this document.
 
@@ -24,7 +24,7 @@ way or extend this document.
 
 ## Reporting bugs
 
-Prefered way to report a bug is to open an issue on GitHub. If not possible,
+Preferred way to report a bug is to open an issue on GitHub. If not possible,
 you can also contact the development team directly with an e-mail.
 
 Please look also at detailed instructions here [here](doc/REPORTING-BUGS.md).
@@ -46,7 +46,7 @@ The pull request should represent a coherent unit, like a single feature added.
 More features should be separated to multiple pull request (of course if possible
 and eg. not firmly bound together).
 
-The contained commits shouls present clearly what was changed. Ideally,
+The contained commits should present clearly what was changed. Ideally,
 if refactoring is done, it should not be mixed with functional changes
 in a single commit, similarly for the code movement.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Using the UltraGrid System
 
    The **\<capture_device\>** is one of the list viewed with `-t help`. Name
    of capture device usually follows with configuration of video mode,
-   video input etc. All options can be interactively dispayed using built-in
+   video input etc. All options can be interactively displayed using built-in
    help, eg. `-t decklink:help`.
 
    The **\<compression\>** specifies the selected video compression to be

--- a/cuda_dxt/rgb2dxt1.c
+++ b/cuda_dxt/rgb2dxt1.c
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
         return -1;
     }
     
-    /* prepare envents for time emasurement and begin */
+    /* prepare events for time emasurement and begin */
     cudaEventCreate(&event_end);
     cudaEventCreate(&event_begin);
     cudaEventRecord(event_begin, 0);

--- a/cuda_dxt/rgb2dxt6.c
+++ b/cuda_dxt/rgb2dxt6.c
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
         return -1;
     }
     
-    /* prepare envents for time emasurement and begin */
+    /* prepare events for time emasurement and begin */
     cudaEventCreate(&event_end);
     cudaEventCreate(&event_begin);
     cudaEventRecord(event_begin, 0);

--- a/doc/PERFORMANCE-TUNING.md
+++ b/doc/PERFORMANCE-TUNING.md
@@ -73,7 +73,7 @@ Display devices
 
    If you intend to use some of DXT compressions, recommended driver
    is OpenGL, which can display it natively. When using other display
-   drivers, decompression is still done throught OpenGL and then displayed
+   drivers, decompression is still done through OpenGL and then displayed
    with requested video driver.
 
 
@@ -87,7 +87,7 @@ Other Factors
 
    The UltraGrid system will attempt to enable POSIX real-time scheduling
    to improve performance. This behaviour is disabled by default now, because
-   it can occupy the whole system when enabled, but it can be stil enabled by
+   it can occupy the whole system when enabled, but it can be still enabled by
    '--enable-rt' configure option. If you see the message:
 
         WARNING: Unable to set real-time scheduling

--- a/doc/REPORTING-BUGS.md
+++ b/doc/REPORTING-BUGS.md
@@ -5,7 +5,7 @@ There are couple of ways to report a problem:
   - you can use [GitHub issues](https://github.com/CESNET/UltraGrid/issues)
     for reporting bugs. You need to register, but it is only matter
     of filling username and password.
-  - alternativey you can use our an e-mail conference ultragrid-dev _\_at\__
+  - alternatively you can use our an e-mail conference ultragrid-dev _\_at\__
     cesnet.cz which leads to developers of UltraGrid
   - if not sure if the problem is a bug, you can also use
     [GitHub discussions](https://github.com/CESNET/UltraGrid/discussions)
@@ -63,7 +63,7 @@ to collect data about a computer and attach its result (Linux/macOS).
 a _core dump_ (if generated) and the _binary_ (if you compiled by yourself,
 otherwise the _executable version_). If core dump is not generated, a
 _backtrace_ (see below) might have been generated to standard error output so
-please attach this. Also the terminal output containg the _error context_ would
+please attach this. Also the terminal output containing the _error context_ would
 be helpful.
 
 ## Decoding stacktrace (Linux)

--- a/dxt_compress/dxt_common.h
+++ b/dxt_compress/dxt_common.h
@@ -102,7 +102,7 @@ dxt_init();
 /**
  * Load RGB image from file
  * 
- * @param filaname Image filename
+ * @param filename Image filename
  * @param width Image width in pixels
  * @param height Image height in pixels
  * @return image data buffer or zero if fails
@@ -113,7 +113,7 @@ dxt_image_load_from_file(const char* filename, int width, int height, DXT_IMAGE_
 /**
  * Load RGB image from file
  * 
- * @param filaname Image filename
+ * @param filename Image filename
  * @param width Image width in pixels
  * @param height Image height in pixels
  * @return image data buffer or zero if fails
@@ -124,7 +124,7 @@ dxt_image_save_to_file(const char* filename, DXT_IMAGE_TYPE* image, int width, i
 /**
  * Load compressed image from file
  * 
- * @param filaname Image filename
+ * @param filename Image filename
  * @param width Image width in pixels
  * @param height Image height in pixels
  * @return 0 if succeeds, otherwise nonzero

--- a/gui/QT/util/control_port.cpp
+++ b/gui/QT/util/control_port.cpp
@@ -12,7 +12,7 @@ ControlPort::ControlPort(){
 }
 
 void ControlPort::connect(int local_port){
-	/* Prevents failure in case the socket is alredy connecting. This also
+	/* Prevents failure in case the socket is already connecting. This also
 	 * discards pending data in the send buffer, but we don't care about
 	 * that.*/
 	socket.abort();

--- a/ldgm/matrix-gen/ldpc-matrix.cpp
+++ b/ldgm/matrix-gen/ldpc-matrix.cpp
@@ -43,7 +43,7 @@ void left_matrix_init ( char **matrix, int k, int n, int N1, int seed )
     int j;                      /* Column index */
     int h;                      /* Temporary variable */
     int t;                      /* Left limit within the list of possible choices u[] */
-    int u[3*LDGM_MAX_K];            /* A table used to have a homogenous 1 distribution. */
+    int u[3*LDGM_MAX_K];            /* A table used to have a homogeneous 1 distribution. */
 
     Rand_pmms rand_gen;
     rand_gen.seedi(seed);
@@ -53,13 +53,13 @@ void left_matrix_init ( char **matrix, int k, int n, int N1, int seed )
 	u[h] = h % (n-k);
     }
 
-    /*  Initialize the matrix with N1 "1s" per column, homogenously */
+    /*  Initialize the matrix with N1 "1s" per column, homogeneously */
     t = 0;
     for ( j = 0; j < k; j++ )                   /* for each source symbol column */
     {
 	for ( h = 0; h < N1; h++ )              /* put N1 "1s" */
 	{
-	    /*  Check wether valid available choices remain */
+	    /*  Check whether valid available choices remain */
 	    for ( i = t; i < N1*k && matrix [u[i]] [j] ; i++);
 	    if ( i < N1*k )
 	    {

--- a/ldgm/src/ldgm-session-cpu.cpp
+++ b/ldgm/src/ldgm-session-cpu.cpp
@@ -298,7 +298,7 @@ LDGM_session_cpu::decode_frame ( char* received, int buf_size, int* frame_size,
 
     /*      for(map<int, Node>::iterator it = graph.nodes.begin(); it != graph.nodes.end(); ++it) {
      *      Node n = it->second;
-     *      printf ( "neigbours of %d (count %lu): ", it->first, (it->second).neighbours.size() );
+     *      printf ( "neighbours of %d (count %lu): ", it->first, (it->second).neighbours.size() );
      *      for(vector<int>::iterator itr = n.neighbours.begin(); itr != n.neighbours.end(); ++itr)
      *          printf ( "%d ", *itr );
      *      printf ( "\n" );
@@ -395,7 +395,7 @@ LDGM_session_cpu::decode_frame ( char* received, int buf_size, int* frame_size,
     int iter = 0;
 
     while ( needs_decoding(&graph) && iter < 4) {
-//	printf ( "iteratin\n" );
+//	printf ( "iterating\n" );
         iterate(&graph);
         iter++;
     }

--- a/ldgm/src/ldgm-session-gpu.h
+++ b/ldgm/src/ldgm-session-gpu.h
@@ -3,7 +3,7 @@
  *
  *       Filename:  ldgm-session-gpu.h
  *
- *    Description:  GPU implementation fo LDGM coding
+ *    Description:  GPU implementation of LDGM coding
  *
  *        Version:  1.0
  *        Created:  04/12/2012 12:54:51 PM

--- a/ldgm/src/main.cpp
+++ b/ldgm/src/main.cpp
@@ -108,7 +108,7 @@ main ( int argc, char *argv[] )
 		else if ( isprint ( optopt))
 		    fprintf ( stderr, "Unknown option '-%c'.\n", optopt);
 		else
-		    fprintf ( stderr, "Uknown option character '\\x%x'.\n", optopt);
+		    fprintf ( stderr, "Unknown option character '\\x%x'.\n", optopt);
 
 		return 1;
 	    default:
@@ -194,7 +194,7 @@ demo(int k, int m, int frame_size, char* matrix_fname, char* data_fname, int cpu
     for ( int i = 0; i < frame_size; ++i)
 	memset((char*)data+i, rand() % 256, 1);
 
-    //alocate space for parity packets
+    //allocate space for parity packets
 
 //    void *parity;
     //allocate memory with address aligned to 16 bytes

--- a/ldgm/src/tanner.cpp
+++ b/ldgm/src/tanner.cpp
@@ -55,7 +55,7 @@ int Node::setDataPtr(char *d) {
 
 
 /*-----------------------------------------------------------------------------
- *  Implementation fo class Edge
+ *  Implementation of class Edge
  *-----------------------------------------------------------------------------*/
 
 Edge::Edge(Node *a, Node *b) {
@@ -65,7 +65,7 @@ Edge::Edge(Node *a, Node *b) {
 
 
 /*-----------------------------------------------------------------------------
- *  Implementation fo class Tanner_graph
+ *  Implementation of class Tanner_graph
  *-----------------------------------------------------------------------------*/
 void Tanner_graph::set_data_size(int size) {
     data_size = size;

--- a/nat-helper/room.cpp
+++ b/nat-helper/room.cpp
@@ -79,7 +79,7 @@ void Room::onClientCandidate(Client& client, CompletionStatus status){
 		return;
 	}
 
-	std::cout << "Client candidate recieved" << std::endl;
+	std::cout << "Client candidate received" << std::endl;
 
 	for(auto& [c, cu] : clients){
 		if(&client == c)

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -268,8 +268,8 @@ sdp_send_change_address_message(struct module           *root,
 
 /**
  * take care that addrs can also be comma-separated list of addresses !
- * @retval  0 state succesfully initialized
- * @retval <0 error occured
+ * @retval  0 state successfully initialized
+ * @retval <0 error occurred
  * @retval >0 success but no state was created (eg. help printed)
  */
 int audio_init(struct state_audio **ret,
@@ -446,7 +446,7 @@ int audio_init(struct state_audio **ret,
                 s->receiver = NET_JACK;
 #endif
         } else if (s->audio_tx_mode != 0) {
-                log_msg(LOG_LEVEL_ERROR, "Unknow audio protocol: %s\n", opt->proto);
+                log_msg(LOG_LEVEL_ERROR, "Unknown audio protocol: %s\n", opt->proto);
                 goto error;
         }
 
@@ -891,7 +891,7 @@ static struct response *audio_sender_process_message(struct state_audio *s, stru
                                 exit_uv(0);
                         } else {
                                 LOG(LOG_LEVEL_ERROR)
-                                    << "[control] Unable to initalize FEC!\n";
+                                    << "[control] Unable to initialize FEC!\n";
                         }
                         return new_response(RESPONSE_INT_SERV_ERR, nullptr);
                 }

--- a/src/audio/capture/jack.c
+++ b/src/audio/capture/jack.c
@@ -233,7 +233,7 @@ static void * audio_cap_jack_init(struct module *parent, const char *cfg)
         s->data = ring_buffer_init(s->frame.max_size);
         
         if (s->libjack->set_sample_rate_callback(s->client, jack_samplerate_changed_callback, (void *) s)) {
-                log_msg(LOG_LEVEL_ERROR, MOD_NAME "Registring callback problem.\n");
+                log_msg(LOG_LEVEL_ERROR, MOD_NAME "Registering callback problem.\n");
                 goto release_client;
         }
 

--- a/src/audio/capture/sdl_mixer.c
+++ b/src/audio/capture/sdl_mixer.c
@@ -38,7 +38,7 @@
  * @file
  * @todo errata (SDL3 vs SDL2)
  * 1. 1 channel capture (-a ch=1) seem no longer work but there is a workaround
- * 2. unsufficient performance (generates overflow even in default config)
+ * 2. insufficient performance (generates overflow even in default config)
  */
 
 #include "config.h"               // for HAVE_SDL3
@@ -263,7 +263,7 @@ static void * audio_cap_sdl_mixer_init(struct module *parent, const char *cfg)
         if( Mix_OpenAudio(SDL_MIXER_SAMPLE_RATE, audio_format,
                                 s->audio.ch_count, 4096 ) == -1 ) {
 #endif
-                log_msg(LOG_LEVEL_ERROR, MOD_NAME "error initalizing sound: %s\n", Mix_GetError());
+                log_msg(LOG_LEVEL_ERROR, MOD_NAME "error initializing sound: %s\n", Mix_GetError());
                 goto error;
         }
         adjust_ch_count(s);

--- a/src/audio/codec/libavcodec.c
+++ b/src/audio/codec/libavcodec.c
@@ -224,7 +224,7 @@ ADD_TO_PARAM("audio-lavc-decoder", "* audio-lavc-decoder=<decoder_name>\n"
 ADD_TO_PARAM("audio-lavc-encoder", "* audio-lavc-encoder=<encoder_name>\n"
                 "  Use selected audio lavc encoder\n");
 /**
- * Initializates selected audio codec
+ * Initializes selected audio codec
  * @param audio_codec requested audio codec
  * @param direction   which direction will be used (encoding or decoding)
  * @param silent      if true no error messages will be printed.
@@ -330,7 +330,7 @@ get_bitrate(struct libavcodec_codec_state *s)
         const int default_rate =
             mapping[s->output_channel.codec].default_bitrate;
         if (default_rate > 0) {
-                MSG(INFO, "Setting defaulat bit rate: %d bps\n", default_rate);
+                MSG(INFO, "Setting default bit rate: %d bps\n", default_rate);
                 return default_rate;
         }
         return 0;

--- a/src/audio/echo.cpp
+++ b/src/audio/echo.cpp
@@ -153,7 +153,7 @@ struct echo_cancellation * echo_cancellation_init(void)
         s->frame.data = NULL;
         s->frame.sample_rate = s->frame.bps = 0;
 
-        const int ringbuf_sample_count = 2 << 15; //should be divisable by SAMPLES_PER_FRAME
+        const int ringbuf_sample_count = 2 << 15; //should be divisible by SAMPLES_PER_FRAME
         constexpr int bps = 2; //TODO: assuming bps to be 2
 
         s->far_end_ringbuf.reset(ring_buffer_init(ringbuf_sample_count * bps));
@@ -264,7 +264,7 @@ struct audio_frame * echo_cancel(struct echo_cancellation *s, struct audio_frame
         if(s->next_expected_near < steady_clock::now()){
                 /* It is possible that the capture thread starts late or
                  * freezes, which could create an unwanted delay between far
-                 * and near ends.  To partialy protect against this, drop the
+                 * and near ends.  To partially protect against this, drop the
                  * contents of far end buffer, when the last frame arrived more
                  * than 1s ago.
                  */

--- a/src/audio/export.c
+++ b/src/audio/export.c
@@ -123,7 +123,7 @@ static bool configure(struct audio_export *s, struct audio_desc fmt) {
         s->saved_format = fmt;
 
         if ((s->wav = wav_writer_create(s->filename, fmt)) == NULL) {
-                fprintf(stderr, "[Audio export] Error writting header!\n");
+                fprintf(stderr, "[Audio export] Error writing header!\n");
                 return false;
         }
 

--- a/src/audio/filter/delay.cpp
+++ b/src/audio/filter/delay.cpp
@@ -198,7 +198,7 @@ static af_result_code filter(void *state, struct audio_frame **frame){
                 //Write the last delay_size bytes to buffer
                 ring_buffer_write(s->ring.get(), f->data + excess_size, s->delay_size);
 
-                //Move the beggining of frame to the end and prepend delay_size bytes from buffer
+                //Move the beginning of frame to the end and prepend delay_size bytes from buffer
                 memmove(f->data + s->delay_size, f->data, excess_size);
                 ring_buffer_read(s->ring.get(), f->data, s->delay_size);
         }

--- a/src/audio/jack.c
+++ b/src/audio/jack.c
@@ -166,7 +166,7 @@ void reconfigure_send_ch_count(struct state_jack *s, int ch_count)
         while (ports[i]) ++i;
 
         if(i < s->out_channel_count) {
-                log_msg(LOG_LEVEL_ERROR, MOD_NAME "Not enought output ports found matching pattern '%s': "
+                log_msg(LOG_LEVEL_ERROR, MOD_NAME "Not enough output ports found matching pattern '%s': "
                                 "%d requested, %d found\n", s->out_port_pattern, s->record.ch_count, i);
                 log_msg(LOG_LEVEL_WARNING, MOD_NAME "Reducing port count to %d\n", i);
                 s->out_channel_count = i;
@@ -246,7 +246,7 @@ static int attach_input_ports(struct state_jack *s)
          
          while (ports[i]) ++i;
          if(i < s->record.ch_count) {
-                 log_msg(LOG_LEVEL_ERROR, MOD_NAME "Not enought input ports found matching pattern '%s': "
+                 log_msg(LOG_LEVEL_ERROR, MOD_NAME "Not enough input ports found matching pattern '%s': "
                                  "%d requested, %d found\n", s->in_port_pattern, s->record.ch_count, i);
                  log_msg(LOG_LEVEL_ERROR, MOD_NAME "Reducing port count to %d\n", i);
                  s->record.ch_count = i;
@@ -382,8 +382,8 @@ void jack_send(void *state, struct audio_frame *frame)
  *
  * @param[in]  state state returned by jack_init()
  * @param[out] data  @ref pbuf_audio_data
- * @retval     true  if some data are receied
- * @retval     false if no data were receied
+ * @retval     true  if some data are received
+ * @retval     false if no data were received
  */
 bool jack_receive(void *state, void *data)
 {

--- a/src/audio/playback/alsa.c
+++ b/src/audio/playback/alsa.c
@@ -38,7 +38,7 @@
 /*
  * Changes should use Safe ALSA API (http://0pointer.de/blog/projects/guide-to-sound-apis).
  *
- * Please, report all differencies from it here:
+ * Please, report all differences from it here:
  * - used format SND_PCM_FORMAT_S24_LE
  * - used "default" device for arbitrary number of channels
  */

--- a/src/audio/playback/coreaudio.cpp
+++ b/src/audio/playback/coreaudio.cpp
@@ -363,7 +363,7 @@ error:
  * @briew tries to get device id from device name
  * @param name  name of the device to be looked up
  * @param dir   direction - @sa audio_ca_probe for values;
- *              dir is needed only for deafult device names
+ *              dir is needed only for default device names
  */
 AudioDeviceID
 audio_ca_get_device_by_name(const char *name, int dir)

--- a/src/audio/playback/mixer.cpp
+++ b/src/audio/playback/mixer.cpp
@@ -179,7 +179,7 @@ public:
 };
 
 /**
- * In this mixer, no normalization takes place. After mixing and substracting each
+ * In this mixer, no normalization takes place. After mixing and subtracting each
  * participant signal, values are clamped (there is no point doing it prior that -
  * non-normalized mixed value can be out-of-bounds while resulting value with
  * substracted with substracted source may be ok.
@@ -420,7 +420,7 @@ void state_audio_mixer::worker()
                         participant_index++;
                 }
 
-                // substract each source signal from the mix coming to that participant
+                // subtract each source signal from the mix coming to that participant
                 for (auto & pb : participant_frames) {
                         auto mix = mixed.begin();
                         sample_type_source *part = (sample_type_source *)(void *) pb.get_data(0);

--- a/src/audio/resampler.cpp
+++ b/src/audio/resampler.cpp
@@ -68,7 +68,7 @@ using namespace std;
 class audio_frame2_resampler::impl {
         public:
                 virtual std::tuple<bool, audio_frame2> resample(audio_frame2 &a, std::vector<audio_frame2::channel> &out, int new_sample_rate_num, int new_sample_rate_den) = 0;
-                /// @returns 0-terminated C array of suppored BPS in _ascending_ (!) order
+                /// @returns 0-terminated C array of supported BPS in _ascending_ (!) order
                 virtual const int *get_supported_bps() = 0;
                 virtual ~impl() {}
 };

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -93,7 +93,7 @@ std::ostream& operator<<(std::ostream& os, const audio_desc& desc);
 #endif
 
 /**
- * @brief struct used to comunicate with audio capture/playback device
+ * @brief struct used to communicate with audio capture/playback device
  *
  * Always hold uncompressed (PCM) packed interleaved signed data.
  */
@@ -185,7 +185,7 @@ public:
          * @note
          * bps of the frame needs to be 16 bits!
          *
-         * @param resampler_state opaque state that can holds resampler that dosn't need
+         * @param resampler_state opaque state that can holds resampler that does not need
          *                        to be reinitalized during calls on various audio frames.
          *                        It reinitializes itself when needed (when source or new
          *                        sample rate changes). Therefore, it is very recommended

--- a/src/audio/utils.cpp
+++ b/src/audio/utils.cpp
@@ -702,7 +702,7 @@ int parse_audio_format(const char *str, struct audio_desc *ret) {
                         }
                         ret->sample_rate = (int) rate;
                 } else {
-                        LOG(LOG_LEVEL_ERROR) << "Unkonwn option \"" << item << "\" for audio format!\n";
+                        LOG(LOG_LEVEL_ERROR) << "Unknown option \"" << item << "\" for audio format!\n";
                         LOG(LOG_LEVEL_INFO) << "Use \"help\" keyword for syntax.!\n";
                         return -1;
                 }
@@ -792,7 +792,7 @@ bool channel_map::validate() {
         for(int i = 0; i < size; ++i) {
                 for(int j = 0; j < sizes[i]; ++j) {
                         if(map[i][j] < 0) {
-                                log_msg(LOG_LEVEL_ERROR, "Audio channel mapping - negative parameter occured.\n");
+                                log_msg(LOG_LEVEL_ERROR, "Audio channel mapping - negative parameter occurred.\n");
                                 return false;
                         }
                 }

--- a/src/audio/utils.h
+++ b/src/audio/utils.h
@@ -79,7 +79,7 @@ void change_bps2(char *out, int out_bps, const char *in, int in_bps, int in_len 
  * By reducing bit-depth of audio, quantization noise is introduced. If the bit
  * depth is reduced by consistent rounding (either always down, always up, or
  * always to nearest) the quantization noise is correlated with the input
- * signal and percieved as distortion. Adding a small amount of noise to the
+ * signal and perceived as distortion. Adding a small amount of noise to the
  * input signal before reducing the bit-depth causes random rounding, which
  * makes the noise uncorrelated and uniformly spread through the whole
  * spectrum.
@@ -119,14 +119,14 @@ void remux_and_mix_channel(char *out, const char *in, int bps, int frames, int i
 double get_avg_volume(char *data, int bps, int in_len, int stream_channels, int chan_pos_stream);
 
 /**
- * This fuction converts from normalized float to int32_t representation
+ * This function converts from normalized float to int32_t representation
  * Input and output data may overlap.
  * @param[out] out 4-byte aligned output buffer
  * @param[in] in 4-byte aligned input buffer
  */
 void float2int(char *out, const char *in, int len);
 /**
- * This fuction converts from int32_t to normalized float
+ * This function converts from int32_t to normalized float
  * Input and output data may overlap.
  * @param[out] out 4-byte aligned output buffer
  * @param[in] in 4-byte aligned input buffer

--- a/src/audio/wav_reader.c
+++ b/src/audio/wav_reader.c
@@ -278,7 +278,7 @@ int read_wav_header(FILE *wav_file, struct wav_metadata *metadata)
                 return WAV_HDR_PARSE_READ_ERROR;
         }
 
-        if (rf64 && !found_ds64_chunk) { // buggy, but we may try to continue witn implicit data size
+        if (rf64 && !found_ds64_chunk) { // buggy, but we may try to continue with implicit data size
                 log_msg(LOG_LEVEL_WARNING, MOD_NAME "Broken WAV - a RF64 file detected but no ds64 chunk found!\n");
         }
 

--- a/src/audio/wav_writer.c
+++ b/src/audio/wav_writer.c
@@ -54,7 +54,7 @@
  * However, the document [2] doesn't mention this and there is no ambiguity for UG - we do
  * not specify channel layout, bits per sample matches container size and is never padded.
  * Resource [3] also suggests this use but strictly speaking this is documentation of system
- * API, not file format. flac(1) complains if the original format is used, FFmpeg RIFF writter
+ * API, not file format. flac(1) complains if the original format is used, FFmpeg RIFF writer
  * also follows the above rules.
  */
 

--- a/src/blackmagic_common.cpp
+++ b/src/blackmagic_common.cpp
@@ -179,7 +179,7 @@ std::string get_str_from_bmd_api_str(BMD_STR string)
 
 /**
  * @param[out] com_initialized  pointer to be passed to decklnk_uninitialize
- (keeps information if COM needs to be unintialized)
+ (keeps information if COM needs to be uninitialized)
  * @note
  * Each successful call (returning non-null pointer) of this function
  * should be followed by com_uninitialize() when done with DeckLink (not when releasing
@@ -244,7 +244,7 @@ bool blackmagic_api_version_check()
                 goto cleanup;
         }
 
-        // this is safe comparision, for internal structure please see SDK
+        // this is safe comparison, for internal structure please see SDK
         // documentation
         if (value <= BMD_LAST_INCOMPATIBLE_ABI) {
                 MSG(ERROR, "The DeckLink drivers are be outdated.\n");
@@ -408,7 +408,7 @@ class ProfileCallback : public IDeckLinkProfileCallback
                         std::unique_lock<std::mutex> lock(m_profileActivatedMutex);
                         bool ret =  m_profileActivatedCondition.wait_for(lock, std::chrono::seconds{5}, [&]{ return m_requestedProfileActivated; });
                         if (ret) {
-                                LOG(LOG_LEVEL_NOTICE) << "[DeckLink] Profile " << profileName << " activated succesfully.\n";
+                                LOG(LOG_LEVEL_NOTICE) << "[DeckLink] Profile " << profileName << " activated successfully.\n";
                         } else {
                                 LOG(LOG_LEVEL_ERROR) << "[DeckLink] Profile " << profileName << " activation timeouted!\n";
                         }
@@ -958,7 +958,7 @@ bmd_opt_help()
                              val_name_map[i].name);
         }
         color_printf("\n");
-        color_printf("Avaliable values can be found here:\n" TUNDERLINE(
+        color_printf("Available values can be found here:\n" TUNDERLINE(
             "https://github.com/CESNET/UltraGrid/blob/master/ext-deps/"
             "DeckLink/Linux/DeckLinkAPI.h") "\n");
         color_printf("\n");
@@ -987,7 +987,7 @@ bmd_opt_help()
 
 /**
  * @param val  can be empty or NULL - this allow specifying the flag without explicit value
- * @retval true  value vas set
+ * @retval true  value was set
  * @retval false help for FourCC syntas was print
  */
 bool

--- a/src/capture_filter/blank.c
+++ b/src/capture_filter/blank.c
@@ -141,9 +141,9 @@ static int init(struct module *parent, const char *cfg, void **state)
         if (cfg && strcasecmp(cfg, "help") == 0) {
                 printf("Blanks specified rectangular area:\n\n");
                 printf("blank usage:\n");
-                printf("\tblank:x:y:widht:height[:black]\n");
+                printf("\tblank:x:y:width:height[:black]\n");
                 printf("\t\tor\n");
-                printf("\tblank:x%%:y%%:widht%%:height%%[:black]\n");
+                printf("\tblank:x%%:y%%:width%%:height%%[:black]\n");
                 printf("\t(all values in pixels)\n");
                 return 1;
         }

--- a/src/capture_filter/color.c
+++ b/src/capture_filter/color.c
@@ -62,7 +62,7 @@ static int init(struct module *parent, const char *cfg, void **state)
         cfg = cfg ? cfg : ""; // pp passes NULL for empty config
         if (strcmp(cfg, "help") == 0) {
                 color_printf("\nFilter " TERM_FG_RED TERM_BOLD "color" TERM_RESET " computees average color of the picture.\n");
-                color_printf(TERM_FG_YELLOW "Note: currenty only center pixel is printed!\n" TERM_FG_RESET);
+                color_printf(TERM_FG_YELLOW "Note: currently only center pixel is printed!\n" TERM_FG_RESET);
                 return 1;
         }
 

--- a/src/capture_filter/display.c
+++ b/src/capture_filter/display.c
@@ -150,7 +150,7 @@ static int init(struct module *parent, const char *cfg, void **state)
         log_msg(LOG_LEVEL_WARNING, "%s\n", wrap_paragraph(warn));
 
         if (strlen(cfg) == 0 || strcmp(cfg, "help") == 0) {
-                color_printf("Previews captured frame with specified dispay.\n"
+                color_printf("Previews captured frame with specified display.\n"
                           "Usage:\n"
                           "\t" TBOLD("--capture-filter display:<display_cfg>") "\n");
                 return 1;

--- a/src/capture_filter/gamma.cpp
+++ b/src/capture_filter/gamma.cpp
@@ -65,7 +65,7 @@ using std::thread;
 
 struct state_capture_filter_gamma {
 public:
-        int out_depth; ///< 0, 8 or 16 (0 menas keep)
+        int out_depth; ///< 0, 8 or 16 (0 means keep)
         void *vo_pp_out_buffer{}; ///< buffer to write to if we use vo_pp wrapper (otherwise unused)
 
         explicit state_capture_filter_gamma(double gamma, int out_depth) : out_depth(out_depth) {

--- a/src/capture_filter/matrix.c
+++ b/src/capture_filter/matrix.c
@@ -74,10 +74,10 @@ static int init(struct module *parent, const char *cfg, void **state)
                        "Coefficients are applied at unpacked pixels (eg. on Y Cb and Cr channels of UYVY). Result is marked as RGB.\n"
                        "Currently only RGB and UYVY is supported on input. No additional color transformation is performed.\n");
                 printf("\nOptional \"no-bounds-check\" options disables check for overflows/underflows which improves performance\n"
-                                "but may give incorrect results if operation oveflows or underflows.\n");
+                                "but may give incorrect results if operation overflows or underflows.\n");
                 color_printf(
                     "\n" TBOLD("Note: ") "This variant filter is a bit unusual, "
-                                        "expecially when handling UYVY.\n");
+                                        "especially when handling UYVY.\n");
                 color_printf("You may want also to look at " TBOLD(
                     "matrix2") " capture filter/postprocessor.\n\n");
                 return 1;

--- a/src/compat/platform_pipe.cpp
+++ b/src/compat/platform_pipe.cpp
@@ -150,7 +150,7 @@ static int system_pipe(fd_t p[2])
         (void) p;
         return -1;
 #else
-        fprintf(stderr, "Using native pipe instead of custom implementaton.\n");
+        fprintf(stderr, "Using native pipe instead of custom implementation.\n");
         return pipe(p);
 #endif
 }
@@ -168,7 +168,7 @@ int platform_pipe_init(fd_t p[2])
                 return -1;
         }
         if (LOBYTE(wsaData.wVersion) != 2 || HIBYTE(wsaData.wVersion) != 2) {
-                fprintf(stderr, "Counld not found usable version of Winsock.\n");
+                fprintf(stderr, "Could not find usable version of Winsock.\n");
                 WSACleanup();
                 return -1;
         }
@@ -179,7 +179,7 @@ int platform_pipe_init(fd_t p[2])
                 return -1;
         }
         if (LOBYTE(wsaData.wVersion) != 2 || HIBYTE(wsaData.wVersion) != 2) {
-                fprintf(stderr, "Counld not found usable version of Winsock.\n");
+                fprintf(stderr, "Could not find usable version of Winsock.\n");
                 WSACleanup();
                 WSACleanup();
                 return -1;

--- a/src/crypto/crypt_aes.h
+++ b/src/crypto/crypt_aes.h
@@ -42,7 +42,7 @@
 #include "crypt_aes_impl.h"
 
 /*  Generic Defines  */
-#define     DIR_ENCRYPT           0 /*  Are we encrpyting?  */
+#define     DIR_ENCRYPT           0 /*  Are we encrypting?  */
 #define     DIR_DECRYPT           1 /*  Are we decrpyting?  */
 #define     MODE_ECB              1 /*  Are we ciphering in ECB mode?   */
 #define     MODE_CBC              2 /*  Are we ciphering in CBC mode?   */

--- a/src/crypto/crypt_des.c
+++ b/src/crypto/crypt_des.c
@@ -474,7 +474,7 @@ Word s_p7[64] = {               /* Combined S-Box8 and permutation P */
 #define PC2(regC, regD, k) \
         PC2_AUX(regC, regD, k[0], k[1])
 
-unsigned char G_padChar = (char)0;      /* Default pad charcater */
+unsigned char G_padChar = (char)0;      /* Default pad character */
 
 static Word ROTATE_LEFT(Word x)
 {
@@ -494,7 +494,7 @@ static Word ROTATE_RIGHT(Word x)
 ** The S Box transformations and the permutation P are combined in the vectors
 ** s_p0 - s_p7. Permutation E and the MOD 2 addition with the intermediate key
 ** are then done "inline" on each round. The intermediate key is already in a
-** a 8x6bit form because of the modified permuation PC2 used.
+** a 8x6bit form because of the modified permutation PC2 used.
 */
 
 #if !defined(WORDS_BIGENDIAN)
@@ -662,13 +662,13 @@ qfDES(unsigned char *key,
 
         /*
          ** Lots of gotos and code duplication follow (arrgh) but it speeds
-         ** it up a wee bit!
+         ** it up a little bit!
          ** What would be more useful is looking more carefully at the DES
          ** permutations to produce more efficient versions of the macros
          ** of the "auto-generated" versions used in qfDES-aux.c.
          */
 
-        size >>= 3;             /* this is always a multpile of 8 */
+        size >>= 3;             /* this is always a multiple of 8 */
 
         if (what == qfDES_encrypt) {
                 switch ((int)mode) {
@@ -912,7 +912,7 @@ int qfDES_checkWeakKeys(unsigned char *key)
 }
 
 /*
-** The following function attempts to genreate a random key or IV.
+** The following function attempts to generate a random key or IV.
 ** It relies on the randomness of the  of the random(3) function. Although
 ** it is probably not particularly fast, keys and IV will most probably be
 ** generated off-line so it does not matter too much.

--- a/src/crypto/openssl_decrypt.h
+++ b/src/crypto/openssl_decrypt.h
@@ -66,10 +66,10 @@ struct openssl_decrypt_info {
          *
          * @param[in] decrypt decrypt state
          * @param[in] ciphertext encrypted text
-         * @param[in] ciphertext_len lenght of encrypted text
-         * @param[in] aad Aditional Authenticated Data (see openssl_encrypt documentation)
+         * @param[in] ciphertext_len length of encrypted text
+         * @param[in] aad Additional Authenticated Data (see openssl_encrypt documentation)
          * @param[in] aad_len length of aad block
-         * @param[out] plaintext otput plaintext
+         * @param[out] plaintext output plaintext
          * @retval 0 if checksum doesn't match
          * @retval >0 length of output plaintext
          */

--- a/src/crypto/openssl_encrypt.c
+++ b/src/crypto/openssl_encrypt.c
@@ -44,7 +44,7 @@
  * 2. GCM tag after encrypted data
  *
  * Encryption algorithm is set in transmit.cpp, detected on receiver. Required
- * algorightms are currently GCM (default) and CBC.
+ * algorithms are currently GCM (default) and CBC.
  */
 
 #include "crypto/openssl_encrypt.h"

--- a/src/crypto/openssl_encrypt.h
+++ b/src/crypto/openssl_encrypt.h
@@ -83,10 +83,10 @@ struct openssl_encrypt_info {
          * @param[in] plaintext_len length of plain text
          * @param[in] aad           Additional Authenticated Data
          *                          this won't be encrypted but passed in plaintext along ciphertext.
-         *                          These data are autheticated only if working in some AE mode
+         *                          These data are authenticated only if working in some AE mode
          * @param[in] aad_len       length of AAD text
          * @param[out] ciphertext   resulting ciphertext, can be up to (plaintext_len + MAX_CRYPTO_EXCEED) length
-         * @returns   size of writen ciphertext
+         * @returns   size of written ciphertext
          * @retval 0 on error
          */
         int (*encrypt)(struct openssl_encrypt *encryption,

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -137,7 +137,7 @@ void log_msg(int level, const char *format, ...) {
 }
 
 /**
- * @param  id  the identifier that idetifies identical messages (only first
+ * @param  id  the identifier that identifies identical messages (only first
  * message of given ID is printed); use values < 0x8000'0000 for manually
  * generated IDs, the higher values are reserved for automatically generated
  * ones as in MSG_ONCE()
@@ -317,7 +317,7 @@ bool parse_log_cfg(const char *conf_str,
         "* debug-dump=<module>[=<n>][,<module2>[=<n>]\n" \
         "  Dumps specified buffer to a file for debugging, n-th buffer may " \
         "be selected, name is <module>.dump.\n" \
-        "  Avaiable modules: lavc-avframe, lavd-avframe\n"
+        "  Available modules: lavc-avframe, lavd-avframe\n"
 ADD_TO_PARAM("debug-dump", DUMP_FILE_USAGE);
 void debug_file_dump(const char *key, void (*serialize)(const void *data, FILE *), void *data) {
         const char *dump_file_val = get_commandline_param("debug-dump");

--- a/src/deltacast_common.cpp
+++ b/src/deltacast_common.cpp
@@ -518,7 +518,7 @@ static VHD_CORE_BOARDPROPERTY GetPassiveLoopbackProperty(int ChannelIdx)
 }
 
 /// @sa SDK SetLoopbackState() since VideoMaster 6.21 but simplified to the extent
-/// of features suppoprted by the prior versions (passive loopback only)
+/// of features supported by the prior versions (passive loopback only)
 void
 delta_set_loopback_state(HANDLE BoardHandle, int ChannelIndex, BOOL32 State)
 {

--- a/src/export.c
+++ b/src/export.c
@@ -208,7 +208,7 @@ error:
 
 /**
  * Tries to create directories export.<date>[-????]
- * inside directory prefix. If succesful, returns its
+ * inside directory prefix. If successful, returns its
  * name.
  */
 static char *

--- a/src/hd-rum-translator/hd-rum-translator.cpp
+++ b/src/hd-rum-translator/hd-rum-translator.cpp
@@ -4,8 +4,8 @@
  * @author Martin Piatka    <piatka@cesnet.cz>
  *
  * Main part of transcoding reflector. This component provides a runtime
- * for the reflector. Componets are following:
- * - legacy packet reflector (defined in this file) for backward compatiblity.
+ * for the reflector. Components are following:
+ * - legacy packet reflector (defined in this file) for backward compatibility.
  *   It handles those recipient that doesn't need transcoding.
  * - decompressor - decompresses the stream if there are some host that need
  *   transcoding
@@ -504,7 +504,7 @@ static void *writer(void *arg)
                     overlapped_idx += 1;
                 }
             }
-            // reallocate the buffer since the last one will be freeed automaticaly
+            // reallocate the buffer since the last one will be freed automatically
             s->qhead->buf = (char *) malloc(SIZE);
 #else
             for (unsigned int i = 0; i < s->replicas.size(); i++) {
@@ -695,7 +695,7 @@ static int parse_global_opts(int argc, char **argv,
                         usage(argv[0]);
                         return 1;
                 case 'v':
-                        // nothing needed, version is printed everytime
+                        // nothing needed, version is printed every time
                         return 1;
                 case 'V':
                         break; // already handled in common_preinit()

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -74,7 +74,7 @@
 #include <iterator>                     // for size
 #include <map>                          // for map, _Rb_tree_iterator, opera...
 #include <mutex>                        // for mutex, unique_lock
-#include <string_view>                  // for operator<<, operator==, strin...
+#include <string_view>                  // for operator<<, operator==, string...
 #include <sys/types.h>                  // for ssize_t
 #include <tuple>                        // for tuple, get, make_tuple
 #include <unistd.h>                     // for STDERR_FILENO
@@ -483,7 +483,7 @@ struct init_data *common_preinit(int argc, char *argv[])
                 return nullptr;
         }
         if(LOBYTE(wsaData.wVersion) != 2 || HIBYTE(wsaData.wVersion) != 2) {
-                fprintf(stderr, "Counld not found usable version of Winsock.\n");
+                fprintf(stderr, "Could not found usable version of Winsock.\n");
                 WSACleanup();
                 return nullptr;
         }
@@ -620,7 +620,7 @@ void init_root_module(struct module *root_mod) {
  */
 void exit_uv(int status) {
         if (!state_root_static) {
-                log_msg(LOG_LEVEL_WARNING, "%s called witout state registered.\n", __func__);
+                log_msg(LOG_LEVEL_WARNING, "%s called without state registered.\n", __func__);
         }
         state_root_static->exit_status = status;
         state_root_static->broadcast_should_exit();
@@ -940,7 +940,7 @@ void register_param(const char *param, const char *doc)
                         return;
                 }
         }
-        log_msg(LOG_LEVEL_WARNING, "Cannot register param \"%s\", maxmimum number of parameters reached.\n", param);
+        log_msg(LOG_LEVEL_WARNING, "Cannot register param \"%s\", maximum number of parameters reached.\n", param);
 }
 
 bool validate_param(const char *param)
@@ -966,7 +966,7 @@ bool validate_param(const char *param)
  *
  * @note
  * This function will be usually called twice - first with preinit=true and then with false.
- * It is because the bufffering parameter need to be set early (prior to any output). On the
+ * It is because the buffering parameter need to be set early (prior to any output). On the
  * other hand not all params can be set immediately -- modules are not yet registered, so it
  * is called once more the preinit is done.
  */
@@ -1167,7 +1167,7 @@ unregister_should_exit_callback(struct module *mod, void (*callback)(void *),
 
 ADD_TO_PARAM("errors-fatal", "* errors-fatal\n"
                 "  Treats some errors as fatal and exit even though " PACKAGE_NAME " could continue otherwise.\n"
-                "  This allows less severe errors to be catched (which should not occur under normal circumstances).\n"
+                "  This allows less severe errors to be caught (which should not occur under normal circumstances).\n"
                 "  An environment variable ULTRAGRID_ERRORS_FATAL with the same effect can also be used.\n");
 /**
  * Soft version of exit_uv() checks errors-fatal command-line parameters and

--- a/src/host.h
+++ b/src/host.h
@@ -111,7 +111,7 @@ extern int glfw_init_count;
 extern char pixfmt_conv_pref[]; // defined in video_codec.c
 extern char *sage_network_device;
 
-// Both of following varables are non-negative. It indicates amount of milliseconds that
+// Both of following variables are non-negative. It indicates amount of milliseconds that
 // audio or video should be delayed. This shall be used for AV sync control. For
 // getting/setting you can use get_av_delay()/set_av_delay(). All is in milliseconds.
 extern volatile int audio_offset;
@@ -123,7 +123,7 @@ void set_audio_delay(int val);
 #define RATE_AUTO                   (-1) ///< spread packets evenly across frame time (currently 3/4)
 #define RATE_DYNAMIC                (-2) ///< same as @ref RATE_AUTO but occasional excess frame allowed
 #define RATE_MIN                RATE_DYNAMIC
-#define RATE_DEFAULT                (-3) ///< imaginary value, must not be passed to trasmit module
+#define RATE_DEFAULT                (-3) ///< imaginary value, must not be passed to transmit module
 #define RATE_FLAG_FIXED_RATE (1ll<<62ll) ///< use the bitrate as fixed, not capped
 
 struct init_data;

--- a/src/hwaccel_libav_common.h
+++ b/src/hwaccel_libav_common.h
@@ -62,7 +62,7 @@ codec_t hw_accel_to_ug_pixfmt(enum hw_accel_type type);
 const char *hw_accel_to_str(enum hw_accel_type type);
 
 /**
- * hw_accel_state describes the current state of hw. accleration
+ * hw_accel_state describes the current state of hw. acceleration
  */
 
 struct hw_accel_state {
@@ -96,7 +96,7 @@ void hwaccel_state_reset(struct hw_accel_state *hwaccel);
 int create_hw_device_ctx(enum AVHWDeviceType type, AVBufferRef **device_ref);
 
 /**
- * @brief Creates hw. frames conext with given parameters
+ * @brief Creates hw. frames context with given parameters
  *
  * @param s Codec context containing information about decoded video
  * @param format Format of hardware surfaces

--- a/src/keyboard_control.cpp
+++ b/src/keyboard_control.cpp
@@ -40,10 +40,10 @@
  * @file
  * @todo
  * Consider using some abstraction over terminal control mainly because
- * differencies between Linux and Windows (ANSI mode or terminfo?)
+ * differences between Linux and Windows (ANSI mode or terminfo?)
  *
  * @todo
- * - key should not be overriden (eg. preset and custom)
+ * - key should not be overridden (eg. preset and custom)
  * - preset keys and customs ones should be unified (in key mapping)
  */
 
@@ -898,7 +898,7 @@ bool keyboard_control::impl::exec_local_command(const char *command)
                         if (key_mapping.find(key) == key_mapping.end()) {
                                 key_mapping.insert({key, make_pair(command, name)});
                         } else {
-                                LOG(LOG_LEVEL_ERROR) << MOD_NAME << "Trying to register key shortcut " << get_keycode_representation(key) << ", which is already regestered, ignoring.\n";
+                                LOG(LOG_LEVEL_ERROR) << MOD_NAME << "Trying to register key shortcut " << get_keycode_representation(key) << ", which is already registered, ignoring.\n";
                         }
                 }
                 free(ccpy);
@@ -1045,7 +1045,7 @@ void keycontrol_send_key(struct module *root, int64_t key) {
  * @ref message_universal message type is always sent
  * @param[in] sender_mod  module that should receive the message for key
  * @param[in] message     text that will be passed back to receiver_mod if key was pressed
- * @param[in] description optional decription that will be displayed in keyboard control help (may be NULL)
+ * @param[in] description optional description that will be displayed in keyboard control help (may be NULL)
  */
 bool keycontrol_register_key(struct module *receiver_mod, int64_t key, const char *message, const char *description) {
         assert(strchr(message, '#') == nullptr && (description == nullptr || strchr(description, '#') == nullptr));

--- a/src/keyboard_control.h
+++ b/src/keyboard_control.h
@@ -66,7 +66,7 @@ private:
 
 #endif // __cplusplus
 
-// values are byte represenations of escape sequences (without ESC itself)
+// values are byte representations of escape sequences (without ESC itself)
 #define K_UP     0x1b5b41
 #define K_DOWN   0x1b5b42
 #define K_RIGHT  0x1b5b43

--- a/src/lib_common.h
+++ b/src/lib_common.h
@@ -151,7 +151,7 @@ struct NOT_DEFINED_STRUCT_THAT_SWALLOWS_SEMICOLON
 
 /**
  * Similar to @ref REGISTER_MODULE but do not show the module under help
- * of correcponding class (usable for technical or deprecated modules).
+ * of corresponding class (usable for technical or deprecated modules).
  */
 #define REGISTER_HIDDEN_MODULE(name, info, lclass, abi) REGISTER_MODULE_FUNCNAME(name, info, lclass, abi, UNIQUE_LABEL, 1)
 

--- a/src/libavcodec/lavc_common.c
+++ b/src/libavcodec/lavc_common.c
@@ -327,7 +327,7 @@ audio_bps_to_av_sample_fmt(int bps, bool planar)
 }
 
 /**
- * Prints space-separated nammes of AVPixelFormats in AV_PIX_FMT_NONE-terminated
+ * Prints space-separated names of AVPixelFormats in AV_PIX_FMT_NONE-terminated
  * pixfmts list to given buf and returns pointer to given buf.
  */
 const char *
@@ -352,7 +352,7 @@ get_avpixfmts_names(const enum AVPixelFormat *pixfmts)
  * @param ctx   may be nullptr if codec is not
  * @param codec may be nullptr if ctx is not
  *
- * If passed ctx, values such as `strict_std_compliance` may afect the result.
+ * If passed ctx, values such as `strict_std_compliance` may affect the result.
  */
 #if LIBAVCODEC_VERSION_INT >  AV_VERSION_INT(61, 13, 100)
 static const void *

--- a/src/libavcodec/to_lavc_vid_conv.c
+++ b/src/libavcodec/to_lavc_vid_conv.c
@@ -1232,7 +1232,7 @@ void get_av_pixfmt_details(enum AVPixelFormat av_codec, enum AVColorSpace *color
 }
 
 static int get_intermediate_codecs_from_uv_to_av(codec_t in, enum AVPixelFormat av, codec_t fmts[VIDEO_CODEC_COUNT]) {
-        int fmt_set[VIDEO_CODEC_COUNT] = { VIDEO_CODEC_NONE }; // to avoid multiple occurences
+        int fmt_set[VIDEO_CODEC_COUNT] = { VIDEO_CODEC_NONE }; // to avoid multiple occurrences
         for (const struct uv_to_av_pixfmt *i = get_av_to_ug_pixfmts(); i->uv_codec != VIDEO_CODEC_NONE; ++i) { // no AV conversion needed - direct mapping
                 decoder_t decoder = get_decoder_from_to(in, i->uv_codec);
                 if (decoder && i->av_pixfmt == av) {
@@ -1483,7 +1483,7 @@ int get_available_pix_fmts(codec_t in_codec, struct to_lavc_req_prop req_prop,
         }
 
         int sort_start_idx = nb_fmts;
-        int fmt_set[AV_PIX_FMT_NB] = { 0 }; // to avoid multiple occurences; for every added element, comp_data must be also set
+        int fmt_set[AV_PIX_FMT_NB] = { 0 }; // to avoid multiple occurrences; for every added element, comp_data must be also set
         struct lavc_compare_convs_data comp_data = { 0 };
         if (to_lavc_cuda_conv_enabled()) {
                 set_convertible_formats_cuda(in_codec, req_prop, fmt_set,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -845,7 +845,7 @@ parse_options_internal(int argc, char *argv[], struct ug_options *opt)
                                 // there should be setting for both audio and video
                                 // but we conservativelly expect that the user wants
                                 // only vieo and let audio default until explicitly
-                                // stated otehrwise
+                                // stated otherwise
                                 opt->requested_video_fec = optarg;
                         }
                         break;
@@ -1255,8 +1255,8 @@ static int adjust_params(struct ug_options *opt) {
         adjust_ports(opt, audio_rxtx_mode);
 
         // If we are sure that this UltraGrid is sending to itself we can optimize some parameters
-        // (aka "-m 9000 -l unlimited"). If ports weren't equal it is possibile that we are sending
-        // to a reflector, thats why we require equal ports (we are a receiver as well).
+        // (aka "-m 9000 -l unlimited"). If ports weren't equal it is possible that we are sending
+        // to a reflector, that is why we require equal ports (we are a receiver as well).
         if (is_host_loopback(opt->requested_receiver)
                         && (opt->video_rx_port == opt->video_tx_port || opt->video_tx_port == 0)
                         && (opt->audio.recv_port == opt->audio.send_port || opt->audio.send_port == 0)) {
@@ -1383,7 +1383,7 @@ int main(int argc, char *argv[])
         display_flags |= audio_get_display_flags(uv.audio);
 
         // Display initialization should be prior to modules that may use graphic card (eg. GLSL) in order
-        // to initalize shared resource (X display) first
+        // to initialize shared resource (X display) first
         ret =
              initialize_video_display(&uv.root_module, opt.requested_display, opt.display_cfg, display_flags, opt.postprocess, &uv.display_device);
         if (ret < 0) {

--- a/src/messaging.h
+++ b/src/messaging.h
@@ -171,7 +171,7 @@ void module_store_message(struct module *node, struct message *m);
 
 struct response *send_message(struct module *, const char *path, struct message *msg) __attribute__ ((warn_unused_result));
 #define SEND_MESSAGE_FLAG_QUIET    (1<<0) ///< do not print error messages on console (recv not found/queue full)
-#define SEND_MESSAGE_FLAG_NO_STORE (1<<1) ///< if receiver doesn't exist, doesn't store it and retur 404 instead
+#define SEND_MESSAGE_FLAG_NO_STORE (1<<1) ///< if receiver doesn't exist, doesn't store it and return 404 instead
 struct response *send_message_sync(struct module *, const char *path, struct message *msg, int timeout_ms, int flags) __attribute__ ((warn_unused_result));
 struct response *send_message_to_receiver(struct module *, struct message *msg) __attribute__ ((warn_unused_result));
 struct message *new_message(size_t length) __attribute__ ((warn_unused_result));

--- a/src/module.h
+++ b/src/module.h
@@ -49,9 +49,9 @@
  *      ...
  * } s;
  * module_init_default(&s->mod);
- * s->mod.cls = MODULE_CLASS_<NAME>; // allways needed
+ * s->mod.cls = MODULE_CLASS_<NAME>; // always needed
  * s->mod.priv_data = s;             // optional
- * s->mod.deleter = deleter;         // only used for generic modules, see a note bellow
+ * s->mod.deleter = deleter;         // only used for generic modules, see a note below
  * module_register(&s->mod, s->parent);
  * ```
  *
@@ -121,7 +121,7 @@ struct module {
         pthread_mutex_t msg_queue_lock; // protects msg_queue
         struct simple_linked_list *msg_queue;
 
-        struct simple_linked_list *msg_queue_children; ///< messages for childern that were not delivered
+        struct simple_linked_list *msg_queue_children; ///< messages for children that were not delivered
 
         void *priv_data;
         //uint32_t id;

--- a/src/pixfmt_conv.c
+++ b/src/pixfmt_conv.c
@@ -84,7 +84,7 @@
  * @param[out] dst     4-byte aligned output buffer where UYVY will be stored
  * @param[in]  src     4-byte aligned input buffer containing v210 (by definition of v210
  *                     should be even aligned to 16B boundary)
- * @param[in]  dst_len length of data that should be writen to dst buffer (in bytes)
+ * @param[in]  dst_len length of data that should be written to dst buffer (in bytes)
  */
 static void vc_copylinev210(unsigned char * __restrict dst, const unsigned char * __restrict src, int dst_len, int rshift,
                 int gshift, int bshift)
@@ -205,7 +205,7 @@ static void vc_copylineYUYV(unsigned char * __restrict dst, const unsigned char 
  *
  * @param[out] dst     4B-aligned buffer that will contain result
  * @param[in]  src     4B-aligned buffer containing pixels in R10k
- * @param[in]  dst_len length of data that should be writen to dst buffer (in bytes)
+ * @param[in]  dst_len length of data that should be written to dst buffer (in bytes)
  * @param[in]  rshift  destination red shift
  * @param[in]  gshift  destination green shift
  * @param[in]  bshift  destination blue shift
@@ -347,7 +347,7 @@ static void vc_copyliner10ktoRGB(unsigned char * __restrict dst, const unsigned 
  *
  * @param[out] dst     4B-aligned buffer that will contain result
  * @param[in]  src     buffer containing pixels in R12L
- * @param[in]  dst_len length of data that should be writen to dst buffer (in bytes)
+ * @param[in]  dst_len length of data that should be written to dst buffer (in bytes)
  * @param[in]  rshift  ignored
  * @param[in]  gshift  ignored
  * @param[in]  bshift  ignored
@@ -427,7 +427,7 @@ vc_copylineR12LtoRGB(unsigned char * __restrict dst, const unsigned char * __res
  *
  * @param[out] dst     4B-aligned buffer that will contain result
  * @param[in]  src     buffer containing pixels in R12L
- * @param[in]  dstlen  length of data that should be writen to dst buffer (in bytes)
+ * @param[in]  dstlen  length of data that should be written to dst buffer (in bytes)
  * @param[in]  rshift  destination red shift
  * @param[in]  gshift  destination green shift
  * @param[in]  bshift  destination blue shift
@@ -516,7 +516,7 @@ vc_copylineR12L(unsigned char *dst, const unsigned char *src, int dstlen, int rs
  *
  * @param[out] dst     4B-aligned buffer that will contain result
  * @param[in]  src     4B-aligned buffer containing pixels in RGBA
- * @param[in]  dst_len length of data that should be writen to dst buffer (in bytes)
+ * @param[in]  dst_len length of data that should be written to dst buffer (in bytes)
  * @param[in]  rshift  destination red shift
  * @param[in]  gshift  destination green shift
  * @param[in]  bshift  destination blue shift
@@ -746,7 +746,7 @@ static void vc_copylineRGB(unsigned char * __restrict dst, const unsigned char *
  *
  * @param[out] dst     4B-aligned buffer that will contain result
  * @param[in]  src     4B-aligned buffer containing pixels in RGBA
- * @param[in]  dst_len length of data that should be writen to dst buffer (in bytes)
+ * @param[in]  dst_len length of data that should be written to dst buffer (in bytes)
  * @param[in]  rshift  source red shift
  * @param[in]  gshift  source green shift
  * @param[in]  bshift  source blue shift
@@ -1458,7 +1458,7 @@ static void vc_copylineR12LtoRG48(unsigned char * __restrict dst, const unsigned
                 return;
         }
         // compute last incomplete block if dst_len % OUT_BL_SZ != 0, not
-        // writting past the requested dst_len
+        // writing past the requested dst_len
         unsigned char tmp_buf[OUT_BL_SZ];
         vc_copylineR12LtoRG48(tmp_buf, src, OUT_BL_SZ, rshift, gshift, bshift);
         memcpy(dst, tmp_buf, dst_len - x);

--- a/src/pixfmt_conv.h
+++ b/src/pixfmt_conv.h
@@ -73,7 +73,7 @@ extern "C" {
  *
  * dst and src must not overlap.
  *
- * src should have allocated MAX_PADDING bytes more to accomodate some pixel
+ * src should have allocated MAX_PADDING bytes more to accommodate some pixel
  * block conversions requirements (Already done by vf_alloc_desc_data() and by
  * RTP stack.)
  *

--- a/src/playback.c
+++ b/src/playback.c
@@ -97,7 +97,7 @@ int playback_set_device(char *device_string, size_t buf_len, const char *optarg)
 }
 
 /**
- * @param mod moodule that will receive the playback messages
+ * @param mod module that will receive the playback messages
  */
 void playback_register_keyboard_ctl(struct module *mod) {
         struct { int key; const char *msg; } kb[] = {{K_PGUP, "seek +600s"}, {K_PGDOWN, "seek -600s"}, {K_UP, "seek +60s"}, {K_DOWN, "seek -60s"}, {K_LEFT, "seek -10s"}, {K_RIGHT, "seek +10s"}, {' ', "pause"}, {'q', "quit"}};

--- a/src/rtp/audio_decoders.cpp
+++ b/src/rtp/audio_decoders.cpp
@@ -866,7 +866,7 @@ int decode_audio_frame_mulaw(struct coded_data *cdata, void *data, struct pbuf_s
 
                 // For each group of samples.
                 for (int g = 0 ; g < (cdata->data->data_len / received_frame.get_channel_count()) ; g++) {
-                    // Iterate throught each channel.
+                    // Iterate through each channel.
                     for (int ch = 0 ; ch < received_frame.get_channel_count(); ch ++) {
 
                         received_frame.append(ch, from, cdata->data->data_len);

--- a/src/rtp/ldgm.cpp
+++ b/src/rtp/ldgm.cpp
@@ -314,7 +314,7 @@ ldgm::ldgm(const char *cfg)
 
         if(c < MIN_C || c > MAX_C) {
                 ostringstream oss;
-                oss << "[LDGM] C value shoud be inside interval [" << MIN_C << ", " << MAX_C << "]";
+                oss << "[LDGM] C value should be inside interval [" << MIN_C << ", " << MAX_C << "]";
                 throw oss.str();
         }
 

--- a/src/rtp/net_udp.c
+++ b/src/rtp/net_udp.c
@@ -378,7 +378,7 @@ static bool udp_addr_valid4(const char *dst)
 
 /**
  * @returns 1. 0 (htonl(INADDR_ANY)) if iface is "";
- *          2. representation of the address if iface is an adress
+ *          2. representation of the address if iface is an address
  *          3a. [Windows only] interface index
  *          3b. [otherwise] iface local address
  *          4a. [error] htonl(INADDR_ANY) if no IPv4 address on iface
@@ -947,7 +947,7 @@ get_ifindex(const char *iface)
         }
         struct in_addr iface_addr;
         if (inet_pton(AF_INET, iface, &iface_addr) == 1) {
-                error_msg("Interface identified with addres %s not allowed "
+                error_msg("Interface identified with address %s not allowed "
                           "here. Try '-4'...\n",
                           iface);
                 return (unsigned) -1;
@@ -1315,7 +1315,7 @@ static void *udp_reader(void *arg)
                 if (size <= 0) {
                         /// @todo
                         /// In MSW, this block is called as often as packet is sent if
-                        /// we got WSAECONNRESET error (noone is listening). This can have
+                        /// we got WSAECONNRESET error (no one is listening). This can have
                         /// negative performance impact.
                         socket_error("recvfrom");
                         free(packet);

--- a/src/rtp/pbuf.c
+++ b/src/rtp/pbuf.c
@@ -140,7 +140,7 @@ static void pbuf_validate(struct pbuf *playout_buf)
                         /* stored in RTP timestamp order */
                         assert(cpb->rtp_timestamp > ppb->rtp_timestamp);
                         /* stored in playout time order  */
-                        /* TODO: eventually check why is this assert always failng */
+                        /* TODO: eventually check why is this assert always failing */
                         // assert(tv_gt(cpb->ptime, ppb->ptime));  
                 }
                 if (cpb->nxt != NULL) {
@@ -156,7 +156,7 @@ static void pbuf_validate(struct pbuf *playout_buf)
                                 assert(ccd->prv == pcd);
                                 if (ccd->prv != NULL) {
                                         assert(ccd->prv->nxt == ccd);
-                                        /* list is descending - cant really check this now */
+                                        /* list is descending - can not really check this now */
                                         //assert(ccd->seqno < pcd->seqno); 
                                         assert(ccd->data != NULL);
                                 }
@@ -562,7 +562,7 @@ static int frame_complete(struct pbuf_node *frame)
         /* seqnum of the last packet in the previous frame, too?     */
         /* i dont think that would reflect correctly of weather this */
         /* frame is complete or not - however we should check for all */
-        /* the packtes of a frame being present - perhaps we should  */
+        /* the packets of a frame being present - perhaps we should  */
         /* keep a bit vector in pbuf_node? LG.  */
 
         return (frame->mbit == 1 || frame->completed == true);

--- a/src/rtp/rs.cpp
+++ b/src/rtp/rs.cpp
@@ -433,6 +433,6 @@ static void usage() {
             "The n/k ratio determines the redundancy that the FEC provides. "
             "But please note that the " TUNDERLINE("strength")
             " of the FEC applies " TBOLD ("per frame") " basis, so 20%"
-            " redundancy will cover 20% loss in a signle frame only.\n";
+            " redundancy will cover 20% loss in a single frame only.\n";
         color_printf("%s\n", wrap_paragraph(desc));
 }

--- a/src/rtp/rtp.c
+++ b/src/rtp/rtp.c
@@ -98,7 +98,7 @@
 #define max(a, b)      (((a) > (b))? (a): (b))
 #define min(a, b)      (((a) < (b))? (a): (b))
 
-// IANA/RFC 6335 suggested range 49152-65535. Implementatins may differ, eg. Linux uses 32768-60999.
+// IANA/RFC 6335 suggested range 49152-65535. Implementations may differ, eg. Linux uses 32768-60999.
 #define RTP_IPPORT_DYNAMIC ((1U<<15U) + (1U<<14U))
 #define RTP_IPPORT_MAX ((1U<<16U) - 1U)
 #define MOD_NAME "[rtp] "
@@ -311,7 +311,7 @@ struct rtp {
         /* tfrc sender variables */
         uint32_t cmp_rtt;       /* rtt as computed by the sender */
         uint16_t new_rtt;       /* flag change in value of the RTT */
-        /* tfrc recevier variables */
+        /* tfrc receiver variables */
         uint32_t rcv_rtt;       /* rtt receiver extracts from rtp packets */
 
         char *encryption_algorithm;
@@ -982,7 +982,7 @@ static void init_opt(struct rtp *session)
  * rtp_init:
  * @addr: IP destination of this session (unicast or multicast),
  * as an ASCII string.  May be a host name, which will be looked up,
- * or may be an IPv4 dotted quad or IPv6 literal adddress.
+ * or may be an IPv4 dotted quad or IPv6 literal address.
  * @rx_port: The port to which to bind the UDP socket
  * @tx_port: The port to which to send UDP packets
  * @ttl: The TTL for both multicast and unicast (-1 for default)
@@ -1010,7 +1010,7 @@ struct rtp *rtp_init(const char *addr,
  * rtp_init_if:
  * @addr: IP destination of this session (unicast or multicast),
  * as an ASCII string.  May be a host name, which will be looked up,
- * or may be an IPv4 dotted quad or IPv6 literal adddress.
+ * or may be an IPv4 dotted quad or IPv6 literal address.
  * @iface: If the destination of the session is multicast,
  * the optional interface to bind to.  May be NULL, in which case
  * the default multicast interface as determined by the system
@@ -1132,7 +1132,7 @@ struct rtp *rtp_init_if(const char *addr, const char *iface,
         session->sender_count = 0;
         session->initial_rtcp = TRUE;
         session->sending_bye = FALSE;
-        session->avg_rtcp_size = -1;    /* Sentinal value: reception of first packet starts initial value... */
+        session->avg_rtcp_size = -1;    /* Sentinel value: reception of first packet starts initial value... */
         session->we_sent = FALSE;
         session->rtcp_bw = rtcp_bw;
         session->sdes_count_pri = 0;
@@ -1229,7 +1229,7 @@ rtp_init_with_udp_socket(struct socket_udp_local *l, struct sockaddr *sa,
         session->sender_count = 0;
         session->initial_rtcp = TRUE;
         session->sending_bye = FALSE;
-        session->avg_rtcp_size = -1;    /* Sentinal value: reception of first packet starts initial value... */
+        session->avg_rtcp_size = -1;    /* Sentinel value: reception of first packet starts initial value... */
         session->we_sent = FALSE;
         session->rtcp_bw = 5 * 1024 * 1024;       /*  FIXME */
         session->sdes_count_pri = 0;
@@ -1282,10 +1282,10 @@ rtp_init_with_udp_socket(struct socket_udp_local *l, struct sockaddr *sa,
  * @session: the RTP session 
  * @ssrc: the SSRC to be used by the RTP session
  * 
- * This function coerces the local SSRC identifer to be ssrc.  For
+ * This function coerces the local SSRC identifier to be ssrc.  For
  * this function to succeed it must be called immediately after
  * rtp_init or rtp_init_if.  The intended purpose of this
- * function is to co-ordinate SSRC's between layered sessions, it
+ * function is to coordinate SSRC's between layered sessions, it
  * should not be used otherwise.
  */
 bool rtp_set_my_ssrc(struct rtp *session, uint32_t ssrc)
@@ -1593,7 +1593,7 @@ static void rtp_process_data(struct rtp *session, uint32_t curr_rtp_ts,
                 udp_set_receiver(session->rtp_socket, sa, sa->sa_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
         }
 
-        /* figure out header lenght based on tfrc_on */
+        /* figure out header length based on tfrc_on */
         /* might as well extract rtt and send_ts     */
         int vlen = 12;          /* vlen = 12 | 16 | 20 */
         if (session->tfrc_on) {
@@ -1720,7 +1720,7 @@ static int validate_rtcp(uint8_t * packet, int len)
         }
 
         /* Check the RTCP version, payload type and padding of the first in  */
-        /* the compund RTCP packet...                                        */
+        /* the compound RTCP packet...                                        */
         if (pkt->common.version != 2) {
                 debug_msg
                     ("Bogus RTCP packet: version number != 2 in the first sub-packet\n");
@@ -1749,7 +1749,7 @@ static int validate_rtcp(uint8_t * packet, int len)
                 is_okay = FALSE;
         }
 
-        /* Check all following parts of the compund RTCP packet. The RTP version */
+        /* Check all following parts of the compound RTCP packet. The RTP version */
         /* number must be 2, and the padding bit must be zero on all apart from  */
         /* the last packet. Try to validate the format of each sub-packet.       */
         do {
@@ -2484,7 +2484,7 @@ int rtp_recv_poll_r(struct rtp **sessions, struct timeval *timeout, uint32_t cur
 /**
  * rtp_add_csrc:
  * @session: the session pointer (returned by rtp_init()) 
- * @csrc: Constributing SSRC identifier
+ * @csrc: Contributing SSRC identifier
  * 
  * Adds @csrc to list of contributing sources used in SDES items.
  * Used by mixers and transcoders.
@@ -2516,7 +2516,7 @@ bool rtp_add_csrc(struct rtp *session, uint32_t csrc)
 /**
  * rtp_del_csrc:
  * @session: the session pointer (returned by rtp_init()) 
- * @csrc: Constributing SSRC identifier
+ * @csrc: Contributing SSRC identifier
  * 
  * Removes @csrc from list of contributing sources used in SDES items.
  * Used by mixers and transcoders.
@@ -2749,7 +2749,7 @@ const rtcp_rr *rtp_get_rr(struct rtp *session, uint32_t reporter,
  *
  * Extensions fields (@extn, @extn_len, @extn_type) are for including
  * application specific information.  When the widest amount of
- * inter-operability is required these fields should be avoided as
+ * interoperability is required these fields should be avoided as
  * some applications discard packets with extensions they do not
  * recognize.
  * 

--- a/src/rtp/rtp.h
+++ b/src/rtp/rtp.h
@@ -321,8 +321,8 @@ bool             rtp_has_receiver(struct rtp *session);
  *
  * Using async API hugely improves performance.
  * Usage is simple - prior to sending a bulk of packets (eg. video frame), rtp_async_start()
- * is started. Then, all packets are sent as usual, exept that neither data nor headers should
- * be altered up to rtp_async_wait() call, which waits upon completition of async operations
+ * is started. Then, all packets are sent as usual, except that neither data nor headers should
+ * be altered up to rtp_async_wait() call, which waits upon completion of async operations
  * started after rtp_async_start(). Caller is responsible that rtp_send_data_hdr() is not called
  * more than nr_packet times.
  */

--- a/src/rtp/rtp_types.h
+++ b/src/rtp/rtp_types.h
@@ -90,7 +90,7 @@
  * 3rd word
  * bits 0 - 31 length
  *
- * 4rd word
+ * 4th word
  * bits 0-15 horizontal resolution
  * bits 16-31 vertical resolution
  *
@@ -119,7 +119,7 @@ typedef uint32_t video_payload_hdr_t[6];
  * 3rd word
  * bits 0 - 31 length
  *
- * 4rd word
+ * 4th word
  * bits 0-5 audio quantization
  * bits 6-31 audio sample rate
  *
@@ -141,7 +141,7 @@ typedef uint32_t audio_payload_hdr_t[5];
  * 3rd word
  * bits 0 - 31 length
  *
- * 4rd word
+ * 4th word
  * bits 0-12 K
  * bits 13-25 M
  * bits 26-31 C
@@ -174,4 +174,4 @@ enum {
         FPS_MAX = 1024, ///< given by UG RTP payload header
 };
 
-#endif // deined RTP_RTP_TYPES_H_EB786480_8B49_4BB4_9707_FF4AD8ED5A50
+#endif // defined RTP_RTP_TYPES_H_EB786480_8B49_4BB4_9707_FF4AD8ED5A50

--- a/src/rtp/rtpdec_h264.c
+++ b/src/rtp/rtpdec_h264.c
@@ -68,7 +68,7 @@
 static const uint8_t start_sequence[] = { 0, 0, 0, 1 };
 
 /**
- * This function extracts important data for futher processing of the stream,
+ * This function extracts important data for further processing of the stream,
  * eg. frame type - for prepending RTSP/SDP sprop-parameter-sets to I-frame and
  * parsing dimensions from SPS NAL.
  *
@@ -530,7 +530,7 @@ width_height_from_hevc_sps(int *widthOut, int *heightOut, unsigned char *data,
      * ...process..
      * hevc_free(h);
      * ````
-     * Also this allow keeping just the SPS parser part from the HEVC streem
+     * Also this allow keeping just the SPS parser part from the HEVC stream
      * decoder. */
 
     uint8_t* rbsp_buf = (uint8_t*)malloc(data_len);

--- a/src/rtp/rtpenc_h264.c
+++ b/src/rtp/rtpenc_h264.c
@@ -61,7 +61,7 @@ static uint32_t get4Bytes(const unsigned char *ptr) {
 /**
  * Returns pointer to next NAL unit in stream.
  *
- * @param with_start_code returned pointer will point to start code preceeding NAL unit, otherwise it will point
+ * @param with_start_code returned pointer will point to start code preceding NAL unit, otherwise it will point
  *                        to NAL unit beginning (skipping the start code)
  */
 static const unsigned char *get_next_nal(const unsigned char *start, long len, _Bool with_start_code) {

--- a/src/rtp/video_decoders.cpp
+++ b/src/rtp/video_decoders.cpp
@@ -174,7 +174,7 @@ using std::vector;
 struct state_video_decoder;
 
 /**
- * Interlacing changing function protoype. The function should be able to change buffer
+ * Interlacing changing function prototype. The function should be able to change buffer
  * in place, that is when dst and src are the same.
  */
 typedef void (*change_il_t)(char *dst, char *src, int linesize, int height, void **state);
@@ -213,7 +213,7 @@ enum decoder_type_t {
  * This structure holds data needed to use a linedecoder.
  */
 struct line_decoder {
-        int                  base_offset;  ///< from the beginning of buffer. Nonzero if decoding from mutiple tiles.
+        int                  base_offset;  ///< from the beginning of buffer. Nonzero if decoding from multiple tiles.
         long                 conv_num;     ///< in->out bpp conv numerator
         long                 conv_den;     ///< in->out bpp conv denominator
         int                  shifts[3];    ///< requested red,green and blue shift (in bits)
@@ -372,7 +372,7 @@ struct state_video_decoder
 
         enum decoder_type_t decoder_type = {};  ///< how will the video data be decoded
         struct line_decoder *line_decoder = NULL; ///< if the video is uncompressed and only pixelformat change
-                                           ///< is neeeded, use this structure
+                                           ///< is needed, use this structure
         vector<struct state_decompress *> decompress_state; ///< state of the decompress (for every substream)
         bool accepts_corrupted_frame = false;     ///< whether we should pass corrupted frame to decompress
         bool buffer_swapped = true; /**< variable indicating that display buffer
@@ -389,7 +389,7 @@ struct state_video_decoder
         enum video_mode   video_mode = {} ;  ///< video mode set for this decoder
         bool          merged_fb = false; ///< flag if the display device driver requires tiled video or not
 
-        timed_message<LOG_LEVEL_WARNING> slow_msg; ///< shows warning ony in certain interval
+        timed_message<LOG_LEVEL_WARNING> slow_msg; ///< shows warning only in certain interval
 
         synchronized_queue<main_msg_reconfigure *, -1> msg_queue;
 
@@ -757,7 +757,7 @@ static void decoder_set_video_mode(struct state_video_decoder *decoder, enum vid
  *                    no decoding will take place.
  * @param encryption  Encryption config string. Currently, this is a passphrase to be
  *                    used. This may change eventually.
- * @return Newly created decoder state. If an error occured, returns NULL.
+ * @return Newly created decoder state. If an error occurred, returns NULL.
  */
 struct state_video_decoder *video_decoder_init(struct module *parent,
                 enum video_mode video_mode,
@@ -921,7 +921,7 @@ bool video_decoder_register_display(struct state_video_decoder *decoder, struct 
         if(ret) {
                 decoder->disp_supported_il_cnt /= sizeof(enum interlacing_t);
         } else {
-                enum interlacing_t tmp[] = { PROGRESSIVE, INTERLACED_MERGED, SEGMENTED_FRAME}; /* default if not said othervise */
+                enum interlacing_t tmp[] = { PROGRESSIVE, INTERLACED_MERGED, SEGMENTED_FRAME}; /* default if not said otherwise */
                 memcpy(decoder->disp_supported_il, tmp, sizeof(tmp));
                 decoder->disp_supported_il_cnt = sizeof(tmp) / sizeof(enum interlacing_t);
         }
@@ -935,7 +935,7 @@ bool video_decoder_register_display(struct state_video_decoder *decoder, struct 
  * @brief This removes display from current decoder.
  *
  * From now on, no video frames will be decoded with current decoder.
- * @see decoder_register_display - the counterpart of this functon
+ * @see decoder_register_display - the counterpart of this function
  *
  * @param decoder decoder from which will the decoder be removed
  */
@@ -1171,7 +1171,7 @@ static change_il_t select_il_func(enum interlacing_t in_il, enum interlacing_t *
         };
 
         int i;
-        /* first try to check if it can be nativelly displayed */
+        /* first try to check if it can be natively displayed */
         for (i = 0; i < il_out_cnt; ++i) {
                 if(in_il == supported[i]) {
                         *out_il = in_il;
@@ -1503,7 +1503,7 @@ static void check_for_mode_change(struct state_video_decoder *decoder,
  * @param cdata        PBUF buffer
  * @param decoder_data @ref vcodec_state containing decoder state and some additional data
  * @retval true        if decoding was successful.
- *                     It stil doesn't mean that the frame will be correctly displayed,
+ *                     It still doesn't mean that the frame will be correctly displayed,
  *                     decoding may fail in some subsequent (asynchronous) steps.
  * @retval false       if decoding failed
  */
@@ -1527,7 +1527,7 @@ int decode_video_frame(struct coded_data *cdata, void *decoder_data, struct pbuf
         int buffer_number = 0;
         bool buffer_swapped = false;
 
-        // We have no framebuffer assigned, exitting
+        // We have no framebuffer assigned, exiting
         if(!decoder->display) {
                 vf_free(frame);
                 return false;

--- a/src/transmit.cpp
+++ b/src/transmit.cpp
@@ -205,7 +205,7 @@ static void tx_update(struct tx *tx, struct video_frame *frame, int substream)
 }
 
 /**
- * @brief intitializes transmission
+ * @brief initializes transmission
  *
  * @param encryption passcode to be used to encrypt the data; NULL or an empty
  * string can be passed
@@ -324,7 +324,7 @@ static bool set_fec(struct tx *tx, const char *fec_const)
                              strchr(fec_cfg, '%') == nullptr)) {
                                 snprintf(msg->fec_cfg, sizeof(msg->fec_cfg),
                                          "LDGM cfg %s", fec_cfg);
-                        } else { // delay creation until we have avarage frame size
+                        } else { // delay creation until we have average frame size
                                 tx->max_loss = atof(fec_cfg);
                         }
                         tx->fec_scheme = FEC_LDGM;
@@ -338,7 +338,7 @@ static bool set_fec(struct tx *tx, const char *fec_const)
                 color_printf("Usage:\n");
                 color_printf("\t" TBOLD("-f [A:|V:]{mult:count|ldgm[:params]|"
                              "rs[:params]}[:nodup]") "\n");
-                color_printf("\nIf neither A: or V: is speciefied, FEC is set "
+                color_printf("\nIf neither A: or V: is specified, FEC is set "
                              "to the video (backward compat).\n\n");
                 ret = false;
         } else {

--- a/src/tv.h
+++ b/src/tv.h
@@ -77,7 +77,7 @@ uint32_t get_std_video_local_mediatime(void);
 typedef long long time_ns_t;
 /// @todo
 /// The naming is inconsistent - whereas US_IN_NS is the 1 us represented in ns,
-/// MS_IN_SEC is count of milliseconds in a second. Unifiy the use.
+/// MS_IN_SEC is count of milliseconds in a second. Unify the use.
 #define MS_IN_NS      1000000
 #define MS_IN_NS_DBL 1000000.0
 #define MS_IN_SEC 1000

--- a/src/types.h
+++ b/src/types.h
@@ -168,7 +168,7 @@ enum interlacing_t {
 /**
  * video_desc represents video description
  * @note
- * in case of tiled video - width and height represent widht and height
+ * in case of tiled video - width and height represent width and height
  * of each tile, eg. for tiled superHD 1920x1080
  */
 struct video_desc {

--- a/src/utils/color_out.cpp
+++ b/src/utils/color_out.cpp
@@ -76,7 +76,7 @@ static bool setWinTermAnsiColors(DWORD stream) {
 
 /// Taken from [rang](https://github.com/agauniyal/rang)
 static bool isMsysPty(int fd) {
-        // Dynamic load for binary compability with old Windows
+        // Dynamic load for binary compatibility with old Windows
         const auto ptrGetFileInformationByHandleEx
                 = reinterpret_cast<decltype(&GetFileInformationByHandleEx)>(reinterpret_cast<void *>(
                                         GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
@@ -157,7 +157,7 @@ is_output_color()
         return isatty(fileno(stdout));
 #endif
 }
-/// sets internal variable color_stdout and retunrs its contents
+/// sets internal variable color_stdout and returns its contents
 bool
 color_output_init()
 {

--- a/src/utils/fs.c
+++ b/src/utils/fs.c
@@ -187,7 +187,7 @@ const char *get_install_root(void) {
 /**
  * opens and returns temporary file and stores its name in filename
  *
- * Caller is resposible for both closing and unlinking the file.
+ * Caller is responsible for both closing and unlinking the file.
  *
  * Reason for this file is because the linker complains about tmpnam as unsafe
  * thus we create a "safer" workaround (at least for POSIX systems) returning

--- a/src/utils/hevc_stream.c
+++ b/src/utils/hevc_stream.c
@@ -5,7 +5,7 @@
  * - removed what not needed (see point above; the included parts are not
  * modified, so the original file may replace this if more advanced parsing
  * needed)
- * - added smoe GCC diag pragmas (suppress warnings)
+ * - added some GCC diag pragmas (suppress warnings)
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */

--- a/src/utils/jpeg_reader.c
+++ b/src/utils/jpeg_reader.c
@@ -703,7 +703,7 @@ read_spiff_header(uint8_t** image, enum jpeg_color_spec *color_space, bool *in_s
                 return -1;
     }
 
-    debug_msg("APP8 SPIFF parsed succesfully, internal color space: %s\n",
+    debug_msg("APP8 SPIFF parsed successfully, internal color space: %s\n",
               color_space_get_name(*color_space));
     *in_spiff = 1;
 
@@ -941,7 +941,7 @@ int jpeg_read_info(uint8_t *image, int len, struct jpeg_info *info)
                         case JPEG_MARKER_EOI:
                                 break;
 
-                        // included because these fixed-sized markers do not contain lenght field
+                        // included because these fixed-sized markers do not contain length field
                         // thus skipping in default branch will misbehave
                         case JPEG_MARKER_RST0:
                         case JPEG_MARKER_RST1:

--- a/src/utils/misc.cpp
+++ b/src/utils/misc.cpp
@@ -357,7 +357,7 @@ bool is_arm_mac() {
 /**
  * @param what  value returned by std::logic_error::what()
  * @returns if given std::invalid_argument message belongs to a stoi/stof
- * converison
+ * conversion
  */
 
 bool invalid_arg_is_numeric(const char *what) {

--- a/src/utils/nat.c
+++ b/src/utils/nat.c
@@ -113,7 +113,7 @@ static bool setup_nat_pmp(struct ug_nat_traverse *state, int video_rx_port, int 
 static void done_nat_pmp(struct ug_nat_traverse *state);
 
 static const struct nat_traverse_info_t {
-        const char *name_short; ///< for command-line specifiction
+        const char *name_short; ///< for command-line specification
         const char *name_long; ///< for output
         bool (*init)(struct ug_nat_traverse *state, int video_rx_port, int audio_rx_port, int lifetime);
         void (*done)(struct ug_nat_traverse *state);
@@ -372,7 +372,7 @@ static bool nat_pmp_add_mapping(natpmp_t *natpmp, int privateport, int publicpor
         }
 
         log_msg(LOG_LEVEL_INFO, MOD_NAME "NAT PMP - Mapped public port %hu protocol %s to local port %hu "
-                        "liftime %u\n",
+                        "lifetime %u\n",
                         response.pnu.newportmapping.mappedpublicport,
                         response.type == NATPMP_RESPTYPE_UDPPORTMAPPING ? "UDP" :
                         (response.type == NATPMP_RESPTYPE_TCPPORTMAPPING ? "TCP" :

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -549,7 +549,7 @@ v4_unmap(const struct sockaddr_in6 *addr6, struct sockaddr_in *buf4)
  * @retval 0  addresses equal
  * @retval >0 struct represents "bigger" address (port)
  * @note
- * v4-mapped ipv6 address is considered eqaul to corresponding AF_INET addr
+ * v4-mapped ipv6 address is considered equal to corresponding AF_INET addr
  */
 int
 sockaddr_compare(const struct sockaddr *x, const struct sockaddr *y)
@@ -591,7 +591,7 @@ sockaddr_compare(const struct sockaddr *x, const struct sockaddr *y)
                         }
                 }
 
-                // sin6_scope_id is opaque so do not cope with endianity
+                // sin6_scope_id is opaque so do not cope with endianness
                 // (actually it is host order on both Linux and Windows)
                 if (IN6_IS_ADDR_LINKLOCAL(&sin_x->sin6_addr) &&
                     sin_x->sin6_scope_id != sin_y->sin6_scope_id) {

--- a/src/utils/net.h
+++ b/src/utils/net.h
@@ -63,7 +63,7 @@ enum {
         /// not including terminating NUL
         IN_PORT_STR_LEN = 5,
         /**
-         * buffer for host:port represenation. If IPv6 address is presented,
+         * buffer for host:port representation. If IPv6 address is presented,
          * enclosed in []. Including terminating NUL byte.
          * @sa get_sockaddr_str
          */

--- a/src/utils/opencl.c
+++ b/src/utils/opencl.c
@@ -205,7 +205,7 @@ get_device(cl_device_type req_type, int req_platform_idx,
         if (req_device_idx >= (int) num_devices) {
                 if (req_type == CL_DEVICE_TYPE_ALL) {
                         MSG(ERROR,
-                            "Defice index %d out of bound (%u devices for "
+                            "Device index %d out of bound (%u devices for "
                             "platform "
                             "%u)\n",
                             req_device_idx, num_devices, num_platforms);

--- a/src/utils/ring_buffer.h
+++ b/src/utils/ring_buffer.h
@@ -51,7 +51,7 @@ extern "C" {
 #endif
 
 /**
- * @warining ring_buffer is generally not thread safe. The exception is when
+ * @warning ring_buffer is generally not thread safe. The exception is when
  * one thread reads and the other writes to the ring buffer (producer-consumer).
  */
 struct ring_buffer;
@@ -133,7 +133,7 @@ int ring_get_write_regions(struct ring_buffer *ring, int requested_len,
  * ring_get_write_regions().
  *
  * @param amount      amount in bytes to discard
- * @return            true if an overflow occured
+ * @return            true if an overflow occurred
  */
 bool ring_advance_write_idx(struct ring_buffer *ring, int amount);
 

--- a/src/utils/string.h
+++ b/src/utils/string.h
@@ -52,7 +52,7 @@ extern "C" {
 bool ends_with(const char *haystick, const char *needle);
 void replace_all(char *in, const char *from, const char *to);
 bool is_prefix_of(const char *haystack, const char *needle);
-/// same as strpbrk but finds in a reverse order (last occurence returned)
+/// same as strpbrk but finds in a reverse order (last occurrence returned)
 char *strrpbrk(char *s, const char *accept);
 void strappend(char **ptr, const char *ptr_end, const char *src);
 void append_sig_desc(char **ptr, const char *ptr_end, int signum);

--- a/src/utils/synchronized_queue.h
+++ b/src/utils/synchronized_queue.h
@@ -56,7 +56,7 @@ struct msg_quit : public msg {};
  * if there is no element in the queue.
  *
  * @tparam T type to be stored
- * @tparam max_len maximal length of the queue until it bloks (-1 means unlimited)
+ * @tparam max_len maximal length of the queue until it blocks (-1 means unlimited)
  */
 template<typename T = struct msg *, int max_len = 1>
 class synchronized_queue {

--- a/src/utils/text.c
+++ b/src/utils/text.c
@@ -63,10 +63,10 @@ int urlencode_rfc3986_eval(int c)
 }
 
 /**
- * Replaces all occurences where eval() evaluates to true with %-encoding
+ * Replaces all occurrences where eval() evaluates to true with %-encoding
  * @param in        input
  * @param out       output array
- * @param max_len   maximal lenght to be written (including terminating NUL)
+ * @param max_len   maximal length to be written (including terminating NUL)
  * @param eval_pass predictor if an input character should be kept (functions
  *                  from ctype.h may be used)
  * @param space_plus_replace replace spaces (' ') with ASCII plus sign -
@@ -120,7 +120,7 @@ static inline int ishex(int x)
  * URL decodes input string (replaces all "%XX" sequences with ASCII representation of 0xXX)
  * @param in      input
  * @param out     output array
- * @param max_len maximal lenght to be written (including terminating NUL)
+ * @param max_len maximal length to be written (including terminating NUL)
  * @returns bytes written, 0 on error
  *
  * @note

--- a/src/utils/time.h
+++ b/src/utils/time.h
@@ -47,7 +47,7 @@ enum {
 };
 
 /**
- * Formats textual represenation of timestamp (in ms) in format HH:MM:SS.mmm
+ * Formats textual representation of timestamp (in ms) in format HH:MM:SS.mmm
  * (mmm is milliseconds).
  *
  * @param[in]   ts   timestamp in ms

--- a/src/utils/vf_split.h
+++ b/src/utils/vf_split.h
@@ -49,7 +49,7 @@ extern "C" {
  * Caller is responsible for allocating memory for all of these: out (to hold
  * all elements), out elements and theirs data member to hold tile data.
  *
- * width must be divisible by x_count && heigth by y_count (!)
+ * width must be divisible by x_count && height by y_count (!)
  *
  * @param out          output video frames array
  *                     the resulting matrix will be stored row-dominant

--- a/src/utils/windows.c
+++ b/src/utils/windows.c
@@ -57,15 +57,15 @@
  * com_uninintialize(). The value should be initialized to false - the current
  * logic can guard only one init/uninit so true is assumed bo be a repeated call.
  * @param[in] err_prefix optional error prefix to be used for eventual error
- * messges (may be NULL)
- * @retval true  if either COM already initalized for this thread or this call
- * initializes COM succesfully
+ * messages (may be NULL)
+ * @retval true  if either COM already initialized for this thread or this call
+ * initializes COM successfully
  * @retval false  COM could not have been initialized
  */
 bool com_initialize(bool *com_initialized, const char *err_prefix)
 {
         if (*com_initialized) {
-                MSG(WARNING, "com_initialized should be initalized to false "
+                MSG(WARNING, "com_initialized should be initialized to false "
                              "upon the call!\n");
         }
 #ifdef _WIN32
@@ -80,7 +80,7 @@ bool com_initialize(bool *com_initialized, const char *err_prefix)
                 return true;
         }
         if (result == RPC_E_CHANGED_MODE) {
-                log_msg(LOG_LEVEL_WARNING, "%sCOM already intiialized with a different mode!\n", err_prefix);
+                log_msg(LOG_LEVEL_WARNING, "%sCOM already initialized with a different mode!\n", err_prefix);
                 return true;
         }
         log_msg(LOG_LEVEL_ERROR, "%sInitialize of COM failed - %s\n", err_prefix, hresult_to_str(result));

--- a/src/utils/worker.h
+++ b/src/utils/worker.h
@@ -49,14 +49,14 @@ extern "C" {
 typedef void *task_result_handle_t;
 typedef void *(*runnable_t)(void *);
 
-// fuctions documented at definition
+// functions documented at definition
 task_result_handle_t task_run_async(runnable_t task, void *data);
 void task_run_async_detached(runnable_t task, void *data);
 void *wait_task(task_result_handle_t handle);
 void task_run_parallel(runnable_t task, int worker_count, void *data, size_t data_size, void **res);
 
 /**
- * @param data_len   in/out processed block length in bytes (multpile of respawn_parallel's size param)
+ * @param data_len   in/out processed block length in bytes (multiple of respawn_parallel's size param)
  */
 typedef void (*respawn_parallel_callback_t)(void *in, void *out, size_t data_len, void *udata);
 void respawn_parallel(void *in, void *out, size_t nmemb, size_t size, respawn_parallel_callback_t c, void *udata);

--- a/src/video.h
+++ b/src/video.h
@@ -50,13 +50,13 @@ extern "C" {
 enum video_mode get_video_mode_from_str(const char *requested_mode);
 /**
  * @brief Returns vertical count of tiles
- * @param mode requestd video mode
+ * @param mode requested video mode
  * @returns vertical count of tiles
  */
 int get_video_mode_tiles_x(enum video_mode mode);
 /**
  * @brief Returns horizontal count of tiles
- * @param mode requestd video mode
+ * @param mode requested video mode
  * @returns horizontal count of tiles
  */
 int get_video_mode_tiles_y(enum video_mode mode);
@@ -64,7 +64,7 @@ int get_video_mode_tiles_y(enum video_mode mode);
 /**
  * @brief Returns description of video mode
  * Eg. "tiled 4K"
- * @param mode requestd video mode
+ * @param mode requested video mode
  */
 const char *get_video_mode_description(enum video_mode mode);
 

--- a/src/video_capture.c
+++ b/src/video_capture.c
@@ -73,7 +73,7 @@ struct vidcap {
         struct module mod;
         void    *state; ///< state of the created video capture driver
         const struct video_capture_info *funcs;
-        uint32_t magic; ///< For debugging. Conatins @ref VIDCAP_MAGIC
+        uint32_t magic; ///< For debugging. Contains @ref VIDCAP_MAGIC
 
         struct capture_filter *capture_filter; ///< capture_filter_state
 };

--- a/src/video_capture/DirectShowGrabber.cpp
+++ b/src/video_capture/DirectShowGrabber.cpp
@@ -289,7 +289,7 @@ static bool common_init(struct vidcap_dshow_state *s) {
 	}
         HANDLE_ERR("Cannot create Video Input Device enumerator");
 
-	// Media processing classes (filters) are conected to a graph.
+	// Media processing classes (filters) are connected to a graph.
 	// Create graph builder -- helper class for connecting of the graph
 	res = CoCreateInstance(CLSID_CaptureGraphBuilder2, NULL, CLSCTX_INPROC_SERVER,
 			IID_ICaptureGraphBuilder2, (void **) &s->graphBuilder);
@@ -475,15 +475,15 @@ vidcap_dshow_probe_internal(device_info **available_cards, int *count,
                 // connect stream config interface to the capture filter
                 res = s->graphBuilder->FindInterface(&PIN_CATEGORY_CAPTURE, &MEDIATYPE_Video, captureFilter,
                                 IID_IAMStreamConfig, (void **) &s->streamConfig);
-		HANDLE_ERR("Cannot find interface for reading capture capabilites");
+		HANDLE_ERR("Cannot find interface for reading capture capabilities");
 
                 int capCount, capSize;
                 // read number of capture device capabilities
                 res = s->streamConfig->GetNumberOfCapabilities(&capCount, &capSize);
-                HANDLE_ERR("Cannot read number of capture capabilites");
+                HANDLE_ERR("Cannot read number of capture capabilities");
                 // check if the format of capture capabilities is the right one
                 if (capSize != sizeof(VIDEO_STREAM_CONFIG_CAPS)) {
-			log_msg(LOG_LEVEL_WARNING, MOD_NAME "vidcap_dshow_help: %s: Unknown format of capture capabilites.\n", name);
+			log_msg(LOG_LEVEL_WARNING, MOD_NAME "vidcap_dshow_help: %s: Unknown format of capture capabilities.\n", name);
                         continue;
                 }
 
@@ -907,7 +907,7 @@ static int vidcap_dshow_init(struct vidcap_params *params, void **state) {
 
 	res = s->graphBuilder->FindInterface(&PIN_CATEGORY_CAPTURE, &MEDIATYPE_Video, s->captureFilter,
 			IID_IAMStreamConfig, (void **) &s->streamConfig);
-	HANDLE_ERR("Cannot find interface for reading capture capabilites");
+	HANDLE_ERR("Cannot find interface for reading capture capabilities");
 
 	// create instance of sample grabber
 	res = CoCreateInstance(CLSID_SampleGrabber, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&s->sampleGrabberFilter));
@@ -925,7 +925,7 @@ static int vidcap_dshow_init(struct vidcap_params *params, void **state) {
 	res = s->sampleGrabber->SetBufferSamples(TRUE);
 	HANDLE_ERR("Cannot set sample grabber to buffer samples");
 
-	// set media type for sample grabber; this is not done a very detailed setup, because it would be unneccessarily complicated to do so
+	// set media type for sample grabber; this is not done a very detailed setup, because it would be unnecessarily complicated to do so
 	AM_MEDIA_TYPE sampleGrabberMT;
 	ZeroMemory(&sampleGrabberMT, sizeof(sampleGrabberMT));
 	sampleGrabberMT.majortype = MEDIATYPE_Video;
@@ -935,9 +935,9 @@ static int vidcap_dshow_init(struct vidcap_params *params, void **state) {
 
 	int capCount, capSize;
 	res = s->streamConfig->GetNumberOfCapabilities(&capCount, &capSize);
-	HANDLE_ERR("Cannot read number of capture capabilites");
+	HANDLE_ERR("Cannot read number of capture capabilities");
 	if (capSize != sizeof(VIDEO_STREAM_CONFIG_CAPS)) {
-		log_msg(LOG_LEVEL_ERROR, MOD_NAME "vidcap_dshow_init: Unknown format of capture capabilites.\n");
+		log_msg(LOG_LEVEL_ERROR, MOD_NAME "vidcap_dshow_init: Unknown format of capture capabilities.\n");
 		goto error;
 	}
 
@@ -953,7 +953,7 @@ static int vidcap_dshow_init(struct vidcap_params *params, void **state) {
 			log_msg(LOG_LEVEL_ERROR, MOD_NAME "Invalid mode index!\n");
 			goto error;
 		}
-		// Some other error occured
+		// Some other error occurred
                 HANDLE_ERR(
                     "Cannot read stream capabilities #%d (index is correct)",
                     s->modeNumber);
@@ -1382,7 +1382,7 @@ static int LocateSubtype(const GUID *pSubtype)
         const GUID *pMediaSubtype;
         INT iPosition = 0;
 
-/* this code is only to optain type data if UNKNOWN
+/* this code is only to obtain type data if UNKNOWN
         fprintf(stderr, "%s ", &pSubtype->Data1);
         fprintf(stderr, "%X ", pSubtype->Data1);
         fprintf(stderr, "%hX ", pSubtype->Data2);

--- a/src/video_capture/aja.cpp
+++ b/src/video_capture/aja.cpp
@@ -363,7 +363,7 @@ void vidcap_state_aja::Init()
         }
 
         if (!mDevice.AcquireStreamForApplication (fourcc, static_cast <uint32_t> (getpid())))
-                throw string("Cannot aquire stream.");
+                throw string("Cannot acquire stream.");
 #endif
 
         CHECK(mDevice.GetEveryFrameServices (mSavedTaskMode));        //      Save the current state before we change it
@@ -556,7 +556,7 @@ AJAStatus vidcap_state_aja::SetupHDMI()
 
 AJAStatus vidcap_state_aja::SetupVideo()
 {
-        //      Set the video format to match the incomming video format.
+        //      Set the video format to match the incoming video format.
         //      Does the device support the desired input source?
         if (!::NTV2DeviceCanDoInputSource (mDeviceID, mInputSource))
                 return AJA_STATUS_BAD_PARAM;    //      Nope
@@ -579,7 +579,7 @@ AJAStatus vidcap_state_aja::SetupVideo()
         CHECK_OK(mDevice.EnableInputInterrupt (mInputChannel), "EnableInputInterrupt failed", NOOP);
         CHECK_OK(mDevice.SubscribeInputVerticalEvent (mInputChannel), "SubscribeInputVerticalEvent failed", NOOP);
 
-        //      Set the video format to match the incomming video format.
+        //      Set the video format to match the incoming video format.
         //      Does the device support the desired input source?
 
         //      If the device supports bi-directional SDI and the
@@ -726,7 +726,7 @@ AJAStatus vidcap_state_aja::SetupAudio (void)
         //      Loopback mode plays whatever audio appears in the input signal when it's
         //      connected directly to an output (i.e., "end-to-end" mode). If loopback is
         //      left enabled, the video will lag the audio as video frames get briefly delayed
-        //      in our ring buffer. Audio, therefore, needs to come out of the (buffered) fram
+        //      in our ring buffer. Audio, therefore, needs to come out of the (buffered) frame
         //      data being played, so loopback must be turned off...
         //
         CHECK(mDevice.SetAudioLoopBack (NTV2_AUDIO_LOOPBACK_OFF, mAudioSystem));

--- a/src/video_capture/bitflow.cpp
+++ b/src/video_capture/bitflow.cpp
@@ -298,7 +298,7 @@ static struct video_frame *vidcap_bitflow_grab(void *state, struct audio_frame *
                                 return NULL;
                         }
                 case kCIEaqAbortedErr:
-                        log_msg(LOG_LEVEL_ERROR, "CiGetOldestNotDeliveredFrame: acquistion aborted\n");
+                        log_msg(LOG_LEVEL_ERROR, "CiGetOldestNotDeliveredFrame: acquisition aborted\n");
                         return NULL;
                 case kCIEdataHWerr:
                         log_msg(LOG_LEVEL_ERROR, "CiWaitNextUndeliveredFrame gave '%s'\n",CiErrStr(circ));
@@ -323,7 +323,7 @@ static struct video_frame *vidcap_bitflow_grab(void *state, struct audio_frame *
                         log_msg(LOG_LEVEL_ERROR, "CiGetUndeliveredCount error\n");
                         return NULL;
                 case kCIEaqAbortedErr:
-                        log_msg(LOG_LEVEL_ERROR, "CiGetOldestNotDeliveredFrame: acquistion aborted\n");
+                        log_msg(LOG_LEVEL_ERROR, "CiGetOldestNotDeliveredFrame: acquisition aborted\n");
                         return NULL;
                 default:
                         log_msg(LOG_LEVEL_ERROR, "CiGetOldestNotDeliveredFrame gave '%s'\n",CiErrStr(circ));

--- a/src/video_capture/bluefish444.cpp
+++ b/src/video_capture/bluefish444.cpp
@@ -438,7 +438,7 @@ static bool setup_audio(struct vidcap_bluefish444_state *s, unsigned int flags)
         s->audio.sample_rate = 48000; // perhaps the driver does not support different
         s->audio.max_size = 4*4096*16;
 
-        LOG(LOG_LEVEL_NOTICE) << "[Blue cap] audio initialized sucessfully: " << audio_desc_from_frame(&s->audio) << "\n";
+        LOG(LOG_LEVEL_NOTICE) << "[Blue cap] audio initialized successfully: " << audio_desc_from_frame(&s->audio) << "\n";
         
         s->hanc_buffer = (unsigned int *) bfAlloc(MAX_HANC_SIZE);
 
@@ -910,7 +910,7 @@ vidcap_bluefish444_init(struct vidcap_params *params, void **state)
                 bfcVideoCaptureStop(s->pSDK[i]);
                 if(BLUE_FAIL(bfcVideoCaptureStart(s->pSDK[i]))) {
                         /* is this really needed? Sometimes this command keeps failing but
-                         * we can stil go on, so ignore this error */
+                         * we can still go on, so ignore this error */
                         //cerr << "Error video capture start failed on channel A" << endl;
                         //goto error;
                 }

--- a/src/video_capture/decklink.cpp
+++ b/src/video_capture/decklink.cpp
@@ -175,7 +175,7 @@ struct device_state {
         IDeckLinkConfiguration     *deckLinkConfiguration = nullptr;
         BMDNotificationCallback    *notificationCallback  = nullptr;
         string                      device_id = "0"; // either numeric value or device name
-        bool                        audio                 = false; /* wheather we process audio or not */
+        bool                        audio                 = false; /* whether we process audio or not */
         struct tile                *tile                  = nullptr;
         bool init(struct vidcap_decklink_state *s, struct tile *tile, BMDAudioConnection audioConnection);
         void check_attributes(struct vidcap_decklink_state *s);
@@ -186,7 +186,7 @@ struct vidcap_decklink_state {
         vector <struct device_state>     state{vector <struct device_state>(1)};
         int                     devices_cnt = 1;
         string                  mode;
-        unsigned int            next_frame_time = 0; // avarege time between frames
+        unsigned int            next_frame_time = 0; // average time between frames
         struct video_frame     *frame{nullptr};
         struct audio_frame      audio{};
         queue<IDeckLinkAudioInputPacket *> audioPackets;
@@ -988,7 +988,7 @@ static HRESULT set_display_mode_properties(struct vidcap_decklink_state *s, stru
         }
         *pf = it->second;
 
-        // get avarage time between frames
+        // get average time between frames
         BMDTimeValue frameRateDuration = 0;
 
         tile->width = displayMode->GetWidth();
@@ -1317,7 +1317,7 @@ bool device_state::init(struct vidcap_decklink_state *s, struct tile *t, BMDAudi
                         MSG(ERROR, "Desired mode index %s is out of bounds.\n", s->mode.c_str());
                 } else if (mode_idx == MODE_SPEC_AUTODETECT) {
                         MSG(ERROR, "Cannot set initial format for "
-                                   "autodetection - perhaps imposible "
+                                   "autodetection - perhaps impossible "
                                    "combinations of parameters were set.\n");
                 } else {
                         assert("Invalid mode spec." && 0);

--- a/src/video_capture/deltacast.cpp
+++ b/src/video_capture/deltacast.cpp
@@ -171,7 +171,7 @@ delta_get_mode(ULONG VideoStandard)
 
 /**
  * Function initialize is intended to be called repeatedly if no signal detected
- * in vidcap_deltacast_init(). This will be tried everytime grab is called and until
+ * in vidcap_deltacast_init(). This will be tried every time grab is called and until
  * initialized.
  */
 static bool wait_for_channel(struct vidcap_deltacast_state *s)

--- a/src/video_capture/deltacast_dvi.cpp
+++ b/src/video_capture/deltacast_dvi.cpp
@@ -545,7 +545,7 @@ vidcap_deltacast_dvi_init(struct vidcap_params *params, void **state)
                 }
         } else {
                 BrdId = 0;
-                printf("[DELTACAST] Automatically choosen device nr. 0\n");
+                printf("[DELTACAST] Automatically chosen device nr. 0\n");
         }
         free(tmp);
         tmp = NULL;
@@ -599,7 +599,7 @@ vidcap_deltacast_dvi_init(struct vidcap_params *params, void **state)
         if (ug_delta_codec_mapping.find(s->codec) != ug_delta_codec_mapping.end()) {
                 Packing = ug_delta_codec_mapping.at(s->codec);
         } else {
-                log_msg(LOG_LEVEL_ERROR, "Unknown pixel formate entered.\n");
+                log_msg(LOG_LEVEL_ERROR, "Unknown pixel format entered.\n");
                 goto no_format;
         }
 

--- a/src/video_capture/dvs.c
+++ b/src/video_capture/dvs.c
@@ -300,7 +300,7 @@ static int vidcap_dvs_init(struct vidcap_params *params, void **state)
                         item = strtok(NULL, ":");
                         if(item) {
                                 snprintf(card_name, sizeof card_name, "PCI,card:%s", item);
-                                printf("[DVS] Choosen card: %s.\n", card_name);
+                                printf("[DVS] Chosen card: %s.\n", card_name);
                         }
                 } else { // new format - key=value
                         char *tmp = fmt;
@@ -321,7 +321,7 @@ static int vidcap_dvs_init(struct vidcap_params *params, void **state)
                                         }
                                 } else if (strncmp(item, "device=", sizeof("device=")) == 0) {
                                         snprintf(card_name, sizeof card_name, "PCI,card:%s", strchr(item, '=') + 1);
-                                        printf("[DVS] Choosen card: %s.\n", card_name);
+                                        printf("[DVS] Chosen card: %s.\n", card_name);
                                 } else if (strncmp(item, "codec=", sizeof("codec=")) == 0) {
                                         s->frame->color_spec = get_codec_from_name(strchr(item, '=') + 1);
                                         if (s->frame->color_spec == VIDEO_CODEC_NONE) {
@@ -514,7 +514,7 @@ static int vidcap_dvs_init(struct vidcap_params *params, void **state)
                         0, /* obsolete - must be 0 */
                         SV_FIFO_DMA_ON, 
                         SV_FIFO_FLAG_NODMAADDR,
-                        0 /*  frames in FIFO - 0 meens let API set the default maximal value*/
+                        0 /*  frames in FIFO - 0 means let API set the default maximal value*/
                         );
         if (res != SV_OK) {
                 goto error;

--- a/src/video_capture/file.c
+++ b/src/video_capture/file.c
@@ -121,7 +121,7 @@ struct vidcap_state_lavf_decoder {
         struct audio_desc audio_desc;
 
         struct simple_linked_list *video_frame_queue;
-        struct simple_linked_list *vid_frm_noaud; // auxilliary queue for worker
+        struct simple_linked_list *vid_frm_noaud; // auxiliary queue for worker
         int max_queue_len;
         struct ring_buffer *audio_data;
         int64_t audio_start_ts;
@@ -976,7 +976,7 @@ get_timestamped_audio(struct vidcap_state_lavf_decoder *s,
         }
         struct audio_frame *aud_frm = get_audio(s, vid_frm);
         if (aud_frm == NULL) {
-                s->audio_frames = -1; // invalide timestamp
+                s->audio_frames = -1; // invalid timestamp
                 return NULL;
         }
         if (s->audio_frames == -1) {

--- a/src/video_capture/import.c
+++ b/src/video_capture/import.c
@@ -39,7 +39,7 @@
  * @todo
  * There is a race condition between audio and video when seeking the stream.
  * Audio may be seeked and video not yet (or vice versa). Since those parts are
- * independent, ther will perhaps be needed to have _getf() and seek completion
+ * independent, there will perhaps be needed to have _getf() and seek completion
  * mutually exclusive. Perhaps not much harmfull, seems that it could cause at
  * most 1 frame AV-desync.
  */
@@ -515,7 +515,7 @@ vidcap_import_init(struct vidcap_params *params, void **state)
                                 TERM_BOLD TERM_FG_RED "\t<directory>" TERM_FG_RESET "{:loop|:mt_reading=<nr_threads>|:o_direct|:exit_at_end|:fps=<fps>|frames=<n>|:disable_audio}\n" TERM_RESET
                                 "where\n"
                                 TERM_BOLD "\t<fps>" TERM_RESET " - overrides FPS from sequence metadata\n"
-                                TERM_BOLD "\t<n>  " TERM_RESET " - use only N first frames fron sequence (if less than available frames)\n");
+                                TERM_BOLD "\t<n>  " TERM_RESET " - use only N first frames from sequence (if less than available frames)\n");
                 free(tmp);
                 return VIDCAP_INIT_NOERR;
         }

--- a/src/video_capture/ndi.cpp
+++ b/src/video_capture/ndi.cpp
@@ -617,7 +617,7 @@ static struct video_frame *vidcap_ndi_grab(void *state, struct audio_frame **aud
                 break;
 
         case NDIlib_frame_type_error:
-                LOG(LOG_LEVEL_ERROR) << MOD_NAME << "Error occured!\n";
+                LOG(LOG_LEVEL_ERROR) << MOD_NAME << "Error occurred!\n";
                 break;
 
         case NDIlib_frame_type_status_change:

--- a/src/video_capture/pipewire.cpp
+++ b/src/video_capture/pipewire.cpp
@@ -80,7 +80,7 @@ using unique_frame = std::unique_ptr<video_frame, frame_deleter>;
 struct vcap_pw_state { 
         pipewire_state_common pw;
 
-        // used exlusively by ultragrid thread
+        // used exclusively by ultragrid thread
         unique_frame in_flight_frame;
 
         std::mutex mut;
@@ -469,7 +469,7 @@ static void show_screen_help() {
         std::cout << "Usage: -t screen_pw[:cursor|:nocrop|:fps=<fps>|:restore=<token_file>]]\n";
         param("cursor") << "make the cursor visible (default hidden)\n";
         param("nocrop") << "when capturing a window do not crop out the empty background\n";
-        param("<fps>") << "prefered FPS passed to PipeWire (PipeWire may ignore it)\n";
+        param("<fps>") << "preferred FPS passed to PipeWire (PipeWire may ignore it)\n";
         param("<token_file>") << "restore the selected window/display from a file.\n\t\tIf not possible, display the selection dialog and save the token to the file specified.\n";
 }
 
@@ -557,7 +557,7 @@ static int vidcap_screen_pw_init(struct vidcap_params *params, void **state)
         /* TODO: The node target_id param when calling stream_connect should be
          * always set to PW_ID_ANY as using object ids is now deprecated.
          * However, the dbus ScreenCast portal doesn't yet expose the object
-         * serial which shoud be used instead.
+         * serial which should be used instead.
          */
         s->node = portalResult.pipewire_node;
 

--- a/src/video_capture/rtsp.c
+++ b/src/video_capture/rtsp.c
@@ -318,14 +318,14 @@ show_help(bool full) {
     color_printf("\nExamples:\n");
     color_printf("\t" TBOLD("uv -t rtsp://192.168.0.30/mystream") "\n");
     color_printf("\t" TBOLD("uv -t rtsp://[fe80::30]/mystream") "\n");
-    color_printf("\t\t- capture streem on implict port (554)\n");
+    color_printf("\t\t- capture stream on implicit port (554)\n");
     color_printf("\t"
         TBOLD("uv -t rtsp://192.168.0.20:8554/mystream") "\n");
-    color_printf("\t\t- capture streem on port 8554 (optionally with "
+    color_printf("\t\t- capture stream on port 8554 (optionally with "
         "authentization)\n");
     color_printf("\t"
         TBOLD("uv -t rtsp://user:pass@[fe80::30]/mystream") "\n");
-    color_printf("\t\t- capture streem on default port with authentization\n");
+    color_printf("\t\t- capture stream on default port with authentization\n");
     color_printf(
         "\t" TBOLD("uv -t rtsp://192.168.0.20/mystream:decompress") "\n");
     color_printf("\t\t- same as first case but decompress the stream "
@@ -686,7 +686,7 @@ vidcap_rtsp_init(struct vidcap_params *params, void **state) {
     s->vrtsp_state.device = rtp_init_if("localhost", s->vrtsp_state.mcast_if, s->vrtsp_state.port, 0, s->vrtsp_state.ttl, s->vrtsp_state.rtcp_bw,
         0, rtp_recv_callback, (uint8_t *) s->vrtsp_state.participants, 0, false);
     if (s->vrtsp_state.device == NULL) {
-        log_msg(LOG_LEVEL_ERROR, "[rtsp] Cannot intialize RTP device!\n");
+        log_msg(LOG_LEVEL_ERROR, "[rtsp] Cannot initialize RTP device!\n");
         vidcap_rtsp_done(s);
         return VIDCAP_INIT_FAIL;
     }
@@ -1011,7 +1011,7 @@ setup_codecs_and_controls_from_sdp(FILE *sdp_file, struct rtsp_state *rtspState)
                 }
 
                 if (media == MEDIA_NONE) {
-                        continue; // either on session level or unkown media
+                        continue; // either on session level or unknown media
                 }
 
                 if (sscanf(line, "a=control:%2000s", buf) == 1) {

--- a/src/video_capture/screen_linux.c
+++ b/src/video_capture/screen_linux.c
@@ -90,7 +90,7 @@ vidcap_screen_linux_init(struct vidcap_params *params, void **state)
         }
         verbose_msg("Trying to initialize screen_x11\n");
         if (getenv("DISPLAY") == NULL) {
-                log_msg(LOG_LEVEL_WARNING, "Trying to initalize screen_x11 but DISPLAY environment variable is not set!\n");
+                log_msg(LOG_LEVEL_WARNING, "Trying to initialize screen_x11 but DISPLAY environment variable is not set!\n");
         }
         vidcap_params_set_driver(params_new, "screen_x11");
         int ret = initialize_video_capture(NULL, params_new, &device);

--- a/src/video_capture/screen_osx.c
+++ b/src/video_capture/screen_osx.c
@@ -199,7 +199,7 @@ static int vidcap_screen_osx_init(struct vidcap_params *params, void **state)
                                                 }
                                         }
                                         if (i == count) {
-                                                log_msg(LOG_LEVEL_ERROR, MOD_NAME "No secondary scren found!\n");
+                                                log_msg(LOG_LEVEL_ERROR, MOD_NAME "No secondary screen found!\n");
                                                 vidcap_screen_osx_done(s);
                                                 return VIDCAP_INIT_FAIL;
                                         }

--- a/src/video_capture/screen_win.c
+++ b/src/video_capture/screen_win.c
@@ -200,7 +200,7 @@ delete_winreg_tree()
             RegDeleteTree(HKEY_CURRENT_USER, SCREEN_CAP_REG_TREE);
         if (err == ERROR_SUCCESS) {
                 MSG(NOTICE,
-                    "Register tree " REG_FRIENDLY_NAME " deleted succesfully.\n");
+                    "Register tree " REG_FRIENDLY_NAME " deleted successfully.\n");
                 return true;
         }
         MSG(ERROR, "Cannot delete " REG_FRIENDLY_NAME " from registry: %s\n",

--- a/src/video_capture/screen_x11.c
+++ b/src/video_capture/screen_x11.c
@@ -446,7 +446,7 @@ static struct video_frame * vidcap_screen_x11_grab(void *state, struct audio_fra
 
         /*
          * The more correct way is to use X pixel accessor (XGetPixel) as in previous version
-         * Unfortunatelly, this approach is damn slow. Current approach might be incorrect in
+         * Unfortunately, this approach is damn slow. Current approach might be incorrect in
          * some configurations, but seems to work currently. To be corrected if there is an
          * opposite case.
          */

--- a/src/video_capture/switcher.c
+++ b/src/video_capture/switcher.c
@@ -92,7 +92,7 @@ static void show_help()
         color_printf("Eg. in:\n" TBOLD(
             "   uv -t switcher -s embedded -F flip -t testcard -s "
             "analog -t decklink") "\n");
-        color_printf("flip & embedded aplies to testcard, analog to decklink.\n");
+        color_printf("flip & embedded applies to testcard, analog to decklink.\n");
         color_printf(
             "See "
             "also: <" TUNDERLINE("https://github.com/CESNET/UltraGrid/wiki/"

--- a/src/video_capture/swmix.c
+++ b/src/video_capture/swmix.c
@@ -37,7 +37,7 @@
  * @brief SW video mix is a virtual video mixer.
  *
  * @todo
- * Reenable configuration file position matching.
+ * Re-enable configuration file position matching.
  *
  * @todo
  * Refactor to use also different scalers than OpenGL (eg. libswscale)
@@ -1139,7 +1139,7 @@ vidcap_swmix_init(struct vidcap_params *params, void **state)
         }
 
         if (s->gl_context.gl_major < 2) {
-                fprintf(stderr, "[swmix] Unsufficient OpenGL version to run SWMix.\n");
+                fprintf(stderr, "[swmix] Insufficient OpenGL version to run SWMix.\n");
                 goto error;
         }
 

--- a/src/video_capture/testcard2.c
+++ b/src/video_capture/testcard2.c
@@ -108,7 +108,7 @@ void * vidcap_testcard2_thread(void *args);
 struct testcard_state2 {
 
         int count;
-        unsigned char *bg; ///< bars coverted to dest color_spec
+        unsigned char *bg; ///< bars converted to dest color_spec
         struct timeval t0;
         struct video_desc desc;
         char *data;
@@ -418,7 +418,7 @@ void * vidcap_testcard2_thread(void *arg)
                 font_candidates += 1;
         }
         if(!font) {
-                MSG(ERROR, "Unable to load any usable font! Last errror: %s\n",
+                MSG(ERROR, "Unable to load any usable font! Last error: %s\n",
                     TTF_GetError());
                 EXIT_THREAD
         }

--- a/src/video_codec.c
+++ b/src/video_codec.c
@@ -214,7 +214,7 @@ struct alternative_fourcc {
  * This array contains FourCC aliases mapping
  */
 static const struct alternative_fourcc fourcc_aliases[] = {
-        // the following two are here because it was sent with wrong endiannes in past
+        // the following two are here because it was sent with wrong endianness in past
         {to_fourcc('A', 'B', 'G', 'R'), to_fourcc('R', 'G', 'B', 'A')},
         {to_fourcc('2', 'B', 'G', 'R'), to_fourcc('R', 'G', 'B', '2')},
 
@@ -464,7 +464,7 @@ bool codec_is_a_rgb(codec_t codec)
         return false;
 }
 
-/** @brief Returns TRUE if specified pixelformat has constant size regardles
+/** @brief Returns TRUE if specified pixelformat has constant size regardless
  * of resolution. If so the block_size value represents the size.
  *
  * Unspecified for compressed codecs.

--- a/src/video_codec.h
+++ b/src/video_codec.h
@@ -61,11 +61,11 @@ extern "C" {
 
 #define MAX_BPS 8 /* for Y416 */  ///< maximal (average) number of pixels per know pixel formats (up-round if needed)
 #define MAX_PADDING 64 ///< maximal padding in bytes that may be needed to align to pixfmt block size for Y416->R12L:
-                       ///< 64 = vc_linesize(8 /*maximal block pix count (R12L)*/, Y416 /*codec with maximal lenght of 1st arg-sized block*/)
+                       ///< 64 = vc_linesize(8 /*maximal block pix count (R12L)*/, Y416 /*codec with maximal length of 1st arg-sized block*/)
 #define MAX_PFB_SIZE   8 ///< maximal pixfmt block size (R12L - 8 B)
 #define PIX_BLOCK_LCM 24 ///< least common multiple of all pixfmt block sizes in pixels (codec_info_t::block_size/codec_info_t::bpp). "contributors:" 8 R12L, 6 v210
 
-/// Prints list of suppored codecs for video module
+/// Prints list of supported codecs for video module
 void             show_codec_help(const char *module, const codec_t *codecs8, const codec_t *codecs10, const codec_t *codecs_ge12);
 /// @returns number of bits per color component
 int              get_bits_per_component(codec_t codec) __attribute__((const));

--- a/src/video_compress.cpp
+++ b/src/video_compress.cpp
@@ -150,7 +150,7 @@ static void compress_process_message(struct compress_state *proxy, struct msg_ch
                         struct response *resp = send_message_to_receiver(proxy->ptr->state[i],
                                         (struct message *) tmp_data);
                         /// @todo
-                        /// Handle responses more inteligently (eg. aggregate).
+                        /// Handle responses more intelligently (eg. aggregate).
                         free_response(r); // frees previous response
                         r = resp;
                 }
@@ -183,12 +183,12 @@ static void compress_process_message(struct compress_state *proxy, struct msg_ch
 /**
  * @brief This function initializes video compression.
  *
- * This function wrapps the call of compress_init_real().
+ * This function wraps the call of compress_init_real().
  * @param[in] parent        parent module
  * @param[in] config_string configuration (in format <driver>:<options>)
  * @param[out] state        created state
- * @retval     0            if state created sucessfully
- * @retval    <0            if error occured
+ * @retval     0            if state created successfully
+ * @retval    <0            if error occurred
  * @retval    >0            finished successfully, no state created (eg. displayed help)
  */
 int compress_init(struct module *parent, const char *config_string, struct compress_state **state) {
@@ -216,7 +216,7 @@ int compress_init(struct module *parent, const char *config_string, struct compr
  * @brief Constructor for compress_state_real
  * @param[in] parent        parent module
  * @param[in] config_string configuration (in format <driver>:<options>)
- * @throws    -1            if error occured
+ * @throws    -1            if error occurred
  * @retval     1            finished successfully, no state created (eg. displayed help)
  */
 compress_state_real::compress_state_real(struct module *parent, const char *config_string) :

--- a/src/video_compress/cineform.cpp
+++ b/src/video_compress/cineform.cpp
@@ -469,7 +469,7 @@ static std::shared_ptr<video_frame> cineform_compress_pop(struct module *state)
 
         timespec_diff(&t_0, &t_1, &t_res);
 
-        printf("[cineform] Encoding %u frame took %f miliseconds.\n", frame_num, t_res.tv_nsec / 1000000.0);
+        printf("[cineform] Encoding %u frame took %f milliseconds.\n", frame_num, t_res.tv_nsec / 1000000.0);
 #endif
         if(status != CFHD_ERROR_OKAY){
                 log_msg(LOG_LEVEL_ERROR, "[cineform] Failed to wait for sample %d\n", status);

--- a/src/video_compress/cmpto_j2k.cpp
+++ b/src/video_compress/cmpto_j2k.cpp
@@ -536,7 +536,7 @@ static shared_ptr<video_frame> get_copy(struct state_video_compress_j2k *s, vide
         return ret;
 }
 
-/// auxilliary data structure passed with encoded frame
+/// auxiliary data structure passed with encoded frame
 struct custom_data {
         custom_data()                               = delete;
         custom_data(custom_data &b)                 = delete;
@@ -890,7 +890,7 @@ static void j2k_compress_push(struct module *state, std::shared_ptr<video_frame>
 
         if (s->pool_in_cuda_memory) {
                 // cmpto_j2k_enc requires the size after postprocess, which
-                // doesn't equeal the IN frame data_len for R12L
+                // doesn't equal the IN frame data_len for R12L
                 const codec_t device_codec = s->precompress_codec == VC_NONE
                                            ? udata->frame->color_spec
                                            : s->precompress_codec;

--- a/src/video_compress/libavcodec.cpp
+++ b/src/video_compress/libavcodec.cpp
@@ -420,7 +420,7 @@ void usage(bool full) {
                 << "\t\t\tbitrate = frame width * frame height * bits_per_pixel * fps\n";
         col() << "\t" << SBOLD("<cqp>") << " use codec-specific constant QP value, for some codecs like MJPEG this is the only quality setting option\n";
         col() << "\t" << SBOLD("<crf>") << " specifies CRF factor (only for libx264/libx265)\n";
-        col() << "\t" << SBOLD("<subsampling>") << " may be one of 444, 422, or 420, default 420 for progresive, 422 for interlaced\n";
+        col() << "\t" << SBOLD("<subsampling>") << " may be one of 444, 422, or 420, default 420 for progressive, 422 for interlaced\n";
         col() << "\t" << SBOLD("<depth>") << " enforce specified compression bit depth\n";
         col() << "\t" << SBOLD("rgb|yuv") << " enforce specified color space compreesion\n";
         col() << "\t" << SBOLD("<threads>") << " can be \"no\", or \"<number>[F][S][n]\" where 'F'/'S' indicate if frame/slice thr. should be used, both can be used (default slice), 'n' means none;\n";
@@ -482,7 +482,7 @@ handle_help(bool full, string const &req_encoder, string const &req_codec)
         if (req_codec == "help") {
                 if (req_encoder.empty()) {
                         MSG(ERROR, "The encoder needs to be specified "
-                                   "explictly for input codec listing!\n");
+                                   "explicitly for input codec listing!\n");
                         return;
                 }
                 const auto *codec =
@@ -649,7 +649,7 @@ static compress_module_info get_libavcodec_module_info(){
                         "Do not use Periodic Intra Refresh (H.264/H.265)", "",
                         "disable_intra_refresh", ":disable_intra_refresh", true});
         module_info.opts.emplace_back(module_option{"Subsampling",
-                        "may be one of 444, 422, or 420, default 420 for progresive, 422 for interlaced",
+                        "may be one of 444, 422, or 420, default 420 for progressive, 422 for interlaced",
                         "422",
                         "subsampling", ":subsampling=", false});
         module_info.opts.emplace_back(module_option{"Lavc opt",
@@ -687,7 +687,7 @@ static compress_module_info get_libavcodec_module_info(){
 
 ADD_TO_PARAM("keep-pixfmt",
                 "* keep-pixfmt\n"
-                "  Signalize input pixel format to reciever and try\n");
+                "  Signalize input pixel format to receiver and try\n");
 struct module * libavcodec_compress_init(struct module *parent, const char *opts)
 {
         ug_set_av_logging();
@@ -1111,7 +1111,7 @@ const AVCodec *get_av_codec(struct state_video_compress_libav *s, codec_t *ug_co
                 return codec;
         }
 
-        // Else, try to open prefered encoder for requested codec
+        // Else, try to open preferred encoder for requested codec
         const char *preferred_encoder = nullptr;
         if (codec_params.find(*ug_codec) != codec_params.end() &&
             codec_params[*ug_codec].get_prefered_encoder) {
@@ -1143,7 +1143,7 @@ static bool configure_swscale(struct state_video_compress_libav *s, struct video
         enum AVPixelFormat sws_in_format = nb_fmts == 0 ? AV_PIX_FMT_UYVY422 : pixfmts[0];
         log_msg(LOG_LEVEL_NOTICE, MOD_NAME "Attempting to use swscale to convert from %s to %s.\n", av_get_pix_fmt_name(sws_in_format), av_get_pix_fmt_name(sws_out_pixfmt));
         if ((s->pixfmt_conversion = to_lavc_vid_conv_init(desc.color_spec, desc.width, desc.height, sws_in_format, s->conv_thread_count)) == nullptr) {
-                log_msg(LOG_LEVEL_ERROR, MOD_NAME "Failed to get sws input conversion.\n"); // shouldn't happen normally, but user may choose imposible codec
+                log_msg(LOG_LEVEL_ERROR, MOD_NAME "Failed to get sws input conversion.\n"); // shouldn't happen normally, but user may choose impossible codec
                 return false;
         }
 
@@ -1681,7 +1681,7 @@ static void set_codec_thread_mode(AVCodecContext *codec_ctx, struct setparam_par
                 } else if ((codec_ctx->codec->capabilities & AV_CODEC_CAP_OTHER_THREADS) == 0 &&
                                 (codec_ctx->codec->capabilities & AV_CODEC_CAP_FRAME_THREADS) != 0) {
                         log_msg(LOG_LEVEL_WARNING, MOD_NAME "Slice-based or external multithreading not available, encoding won't be parallel. "
-                                        "You may select frame-based paralellism if needed.\n");
+                                        "You may select frame-based parallelism if needed.\n");
                 }
         } else if (req_thread_type == -1) {
                 req_thread_type = 0;
@@ -1899,7 +1899,7 @@ configure_x264_x265(AVCodecContext *codec_ctx, struct setparam_param *param)
                 }
         };
         x265_params_append("keyint", to_string(codec_ctx->gop_size));
-        /// turn on periodic intra refresh, unless explicitely disabled
+        /// turn on periodic intra refresh, unless explicitly disabled
         if (param->periodic_intra != 0) {
                 incomp_feature_warn(INCOMP_INTRA_REFRESH, param->periodic_intra);
                 codec_ctx->refs = 1;

--- a/src/video_decompress.cpp
+++ b/src/video_decompress.cpp
@@ -140,7 +140,7 @@ static struct state_decompress *decompress_init(const video_decompress_info *vdi
 }
 
 /**
- * Attemps to initialize decompress of given magic
+ * Attempts to initialize decompress of given magic
  *
  * @param[in]  vdi      metadata struct of requested decompressor
  * @param[out] decompress_state decoder state

--- a/src/video_decompress.h
+++ b/src/video_decompress.h
@@ -93,7 +93,7 @@ typedef enum {
  * @param[in]  state         decompress state
  * @param[out] dst           buffer where uncompressed frame will be written
  * @note
- * Length of the result isn't returned because is known from the informations
+ * Length of the result isn't returned because is known from the information
  * passed with decompress_reconfigure.
  * @param[in] buffer         buffer where uncompressed frame will be written
  * @param[in] src_len        length of the compressed buffer

--- a/src/video_decompress/cmpto_j2k.cpp
+++ b/src/video_decompress/cmpto_j2k.cpp
@@ -41,10 +41,10 @@
  *
  * Problematic part of following code is that UltraGrid decompress API is
  * synchronous only while the CMPTO J2K decoder is inherently asynchronous.
- * Threrefore the integration works in following fashion:
+ * Therefore the integration works in following fashion:
  * - there is a thread that waits for completed (decompressed) frames,
  *   if there is any, it put it in queue (or drop if full)
- * - when a new frame arives, j2k_decompress() passes it to decoder
+ * - when a new frame arrives, j2k_decompress() passes it to decoder
  *   (which is asynchronous, thus non-blocking)
  * - then queue (filled by thread in first point) is checked - if it is
  *   non-empty, frame is copied to framebufffer. If not false is returned.

--- a/src/video_decompress/gpujpeg.c
+++ b/src/video_decompress/gpujpeg.c
@@ -95,10 +95,10 @@ static int configure_with(struct state_decompress_gpujpeg *s, struct video_desc 
         }
 
         // setting verbosity - a bit tricky now, gpujpeg_decoder_init needs to be called with some "valid" data
-        // otherwise, parameter setting is unneeded - it is done automaticaly by the image
+        // otherwise, parameter setting is unneeded - it is done automatically by the image
         struct gpujpeg_parameters param;
         gpujpeg_set_default_parameters(&param);
-        param.color_space_internal = GPUJPEG_YCBCR_BT709; // see comment bellow
+        param.color_space_internal = GPUJPEG_YCBCR_BT709; // see comment below
         param.verbose = MAX(0, log_level - LOG_LEVEL_INFO);
         param.perf_stats = log_level >= LOG_LEVEL_DEBUG ? 1 : 0;
         struct gpujpeg_image_parameters param_image;

--- a/src/video_decompress/libavcodec.c
+++ b/src/video_decompress/libavcodec.c
@@ -424,7 +424,7 @@ static bool configure_with(struct state_libavcodec_decompress *s,
         return true;
 }
 
-/// @retval false if 1. hwacc not enabled; 2. help; 3. incorect hwacc spec
+/// @retval false if 1. hwacc not enabled; 2. help; 3. incorrect hwacc spec
 static bool
 validate_hwacc_param(void)
 {

--- a/src/video_display.c
+++ b/src/video_display.c
@@ -92,7 +92,7 @@
 /// @brief This struct represents initialized video display state.
 struct display {
         struct module mod;
-        uint32_t magic;    ///< For debugging. Conatins @ref DISPLAY_MAGIC
+        uint32_t magic;    ///< For debugging. Contains @ref DISPLAY_MAGIC
         char *display_name;
         const struct video_display_info *funcs;
         void *state;       ///< state of the created video capture driver
@@ -128,7 +128,7 @@ void list_video_display_devices(bool full)
  * @param[in] flags  bit sum of @ref display_flags
  * @param[in] postprocess configuration for display postprocess, _is_ NULL if no present
  * @param[out] out output display state. Defined only if initialization was successful.
- * @retval    0  if sucessful
+ * @retval    0  if successful
  * @retval   -1  if failed
  * @retval    1  if successfully shown help (no state returned)
  */
@@ -388,7 +388,7 @@ static bool display_frame_helper(struct display *d, struct video_frame *frame, l
  *                 Should not be NULL unless we want to quit display mainloop.
  * @param timeout_ns specifies timeout that should be waited (@sa putf_flags).
  *                   displays may ignore the value and act like PUTF_NONBLOCK if blocking is not requested.
- * @retval  true   if displayed succesfully (or discarded if flag=PUTF_DISCARD)
+ * @retval  true   if displayed successfully (or discarded if flag=PUTF_DISCARD)
  * @retval  false  if not displayed when flag=PUTF_NONBLOCK and it would block
  */
 bool display_put_frame(struct display *d, struct video_frame *frame, long long timeout_ns)
@@ -448,7 +448,7 @@ bool display_reconfigure(struct display *d, struct video_desc desc, enum video_m
                 if (vo_postprocess_get_property(d->postprocess, VO_PP_DOES_CHANGE_TILING_MODE,
                                         &pp_does_change_tiling_mode, &len)) {
                         if(len == 0) {
-                                // just for sake of completness since it shouldn't be a case
+                                // just for sake of completeness since it shouldn't be a case
                                 log_msg(LOG_LEVEL_WARNING, "Warning: unable to get pp tiling mode!\n");
                         }
                 }

--- a/src/video_display/aja.cpp
+++ b/src/video_display/aja.cpp
@@ -515,7 +515,7 @@ void display::RouteOutputSignal ()
                         NTV2OutputCrosspointID  fsVidOutXpt             (::GetFrameBufferOutputXptFromChannel (chan,  fbIsRGB/*isRGB*/,  false/*is425*/));
                         if (fbIsRGB != mOutIsRGB) {
                                 CHECK_EX(mDevice.Connect(::GetCSCInputXptFromChannel (chan, false/*isKeyInput*/), fsVidOutXpt),
-                                                "Connnect to CSC", NOOP);
+                                                "Connect to CSC", NOOP);
                         }
 
                         if (NTV2_OUTPUT_DEST_IS_SDI(mConf.outputDestination)) {

--- a/src/video_display/conference.cpp
+++ b/src/video_display/conference.cpp
@@ -552,7 +552,7 @@ static void display_conference_worker(std::shared_ptr<state_conference_common> s
 
         /**
          * We initially set next_frame_time to infinity (or a very long time
-         * from now) to avoid uselessly outputing the same frame twice in a row
+         * from now) to avoid uselessly outputting the same frame twice in a row
          * if we haven't received any new input, because then any new input
          * would have to wait up to 1 frametime adding needless latency.
          */

--- a/src/video_display/decklink_drift_fix.hpp
+++ b/src/video_display/decklink_drift_fix.hpp
@@ -192,14 +192,14 @@ public:
         }
 
         /**
-         * @brief This should be called when an overflow has occured.
+         * @brief This should be called when an overflow has occurred.
          */
         void increment_buffer_overflow() {
                 this->buffer_overflow++;
         }
 
         /**
-         * @brief This should be called when an underflow has occured.
+         * @brief This should be called when an underflow has occurred.
          */
         void increment_buffer_underflow() {
                 this->buffer_underflow++;
@@ -255,7 +255,7 @@ public:
                         std::chrono::high_resolution_clock::time_point audio_begin = std::chrono::high_resolution_clock::now();
                         std::chrono::milliseconds time_diff = std::chrono::duration_cast<std::chrono::milliseconds>(audio_begin - this->prev_audio_end);
 
-                        // Set a max or min if the timing is outside of whats already been collected
+                        // Set a max or min if the timing is outside of what is already been collected
                         long long duration_diff = time_diff.count();
                         if(duration_diff > this->audio_time_diff_max) {
                                 this->audio_time_diff_max = duration_diff;
@@ -281,7 +281,7 @@ private:
         // How many times the buffer dropped avg amount of frames being added
         uint32_t frames_missed = 0;
         MovingAverage avg_added_frames{250};
-        // How many buffer underflows and overflows have occured.
+        // How many buffer underflows and overflows have occurred.
         uint32_t buffer_underflow = 0;
         uint32_t buffer_overflow = 0;
         // How many times it was requested a higher or lower sample rate

--- a/src/video_display/dvs.c
+++ b/src/video_display/dvs.c
@@ -316,7 +316,7 @@ volatile int worker_waiting;
         volatile int audio_reconf_done;
         
         struct ring_buffer * audio_ring_buffer;
-        char *audio_fifo_data; /* temporary memory for the data that gets immediatelly
+        char *audio_fifo_data; /* temporary memory for the data that gets immediately
                                     decoded */
         int audio_fifo_required_size;
         
@@ -425,7 +425,7 @@ static void *display_dvs_run(void *arg)
                         /*  Here is probably bug in recent DVS SDK (4.2.1.1) that triggers
                          *  this error multiple times after device reconfiguration. After few
                          *  frames it disappears.
-                         *  TODO: If ther is no longer the error, remove this comment and exit here.
+                         *  TODO: If there is no longer the error, remove this comment and exit here.
                          */
                 }
 
@@ -615,7 +615,7 @@ static bool display_dvs_reconfigure(void *state,
                         0, /* obsolete, must be zero */
                         SV_FIFO_DMA_ON,
                         SV_FIFO_FLAG_NODMAADDR, /* SV_FIFO_FLAG_* */
-                        0); /* default maximal numer of FIFO buffer frames */
+                        0); /* default maximal number of FIFO buffer frames */
         if (res != SV_OK) {
                 fprintf(stderr, "Cannot initialize video display FIFO %s\n",
                           sv_geterrortext(res));
@@ -941,7 +941,7 @@ static int display_dvs_reconfigure_audio(void *state, int quant_samples, int cha
                         0, /* obsolete, must be zero */
                         SV_FIFO_DMA_ON,
                         SV_FIFO_FLAG_NODMAADDR, /* SV_FIFO_FLAG_* */
-                        0); /* default maximal numer of FIFO buffer frames */
+                        0); /* default maximal number of FIFO buffer frames */
         if (res != SV_OK) {
                 fprintf(stderr, "Cannot initialize audio FIFO %s\n",
                           sv_geterrortext(res));

--- a/src/video_display/file.c
+++ b/src/video_display/file.c
@@ -645,7 +645,7 @@ write_frame(AVFormatContext *format_ctx, struct output_stream *ost,
                 pkt->stream_index = ost->st->index;
                 ret = av_interleaved_write_frame(format_ctx, pkt);
                 if (ret < 0) {
-                        error_msg(MOD_NAME "error writting video packet: %s\n",
+                        error_msg(MOD_NAME "error writing video packet: %s\n",
                                   av_err2str(ret));
                 }
         }

--- a/src/video_display/gl.cpp
+++ b/src/video_display/gl.cpp
@@ -688,14 +688,14 @@ list_hints()
         color_printf(
             "Very " TBOLD("incomplete") " list of hints and its values.\n");
         color_printf("Keywords listed below can be passed to the options "
-                     "instead of the numberic value.\n\n");
+                     "instead of the numeric value.\n\n");
 
         color_printf("The list contains both keys and values for init and "
                      "window hints.\n");
-        color_printf("Window hints start witn 0x20000, init with 0x50000, the "
+        color_printf("Window hints start with 0x20000, init with 0x50000, the "
                      "others are values.\n\n");
 
-        color_printf("For commplete list refer to glfw3.h (eg. online "
+        color_printf("For complete list refer to glfw3.h (eg. online "
                      "<https://github.com/glfw/glfw/blob/master/include/GLFW/"
                      "glfw3.h>).\n\n");
 

--- a/src/video_display/opengl_panorama.hpp
+++ b/src/video_display/opengl_panorama.hpp
@@ -42,7 +42,7 @@
 
 /**
  * Class representing the scene to render. Contains the model and texture to
- * be rendered. Automatically performs pixel format coversions if needed.
+ * be rendered. Automatically performs pixel format conversions if needed.
  * It is possible to call put_frame() from another thread, but limitations apply
  */
 struct PanoramaScene{

--- a/src/video_display/opengl_utils.hpp
+++ b/src/video_display/opengl_utils.hpp
@@ -235,7 +235,7 @@ public:
         /**
          * Attaches a texture to the contained framebuffer
          *
-         * @param tex Texture object containg the texture to attach
+         * @param tex Texture object containing the texture to attach
          */
         void attach_texture(const Texture& tex){
                 attach_texture(tex.get());

--- a/src/video_display/sage.cpp
+++ b/src/video_display/sage.cpp
@@ -220,7 +220,7 @@ static void *display_sage_init(struct module *parent, const char *fmt, unsigned 
                                                          && s->requestedDisplayCodec != DXT5
 #endif // SAGE_NATIVE_DXT5YCOCG
                                                          ) {
-                                                 fprintf(stderr, "Entered codec is not nativelly supported by SAGE.\n");
+                                                 fprintf(stderr, "Entered codec is not natively supported by SAGE.\n");
                                                  free(s); return NULL;
                                          }
                                 } else if(strcmp(item, "tx") == 0) {
@@ -241,7 +241,7 @@ static void *display_sage_init(struct module *parent, const char *fmt, unsigned 
         }
 
         if (!s->is_tx) {
-                // read config file only if we are in dispaly mode (not sender mode)
+                // read config file only if we are in display mode (not sender mode)
                 struct stat sb;
                 if(s->confName) {
                         if(stat(s->confName, &sb)) {

--- a/src/video_display/sdl2.c
+++ b/src/video_display/sdl2.c
@@ -357,7 +357,7 @@ show_help(const char *driver)
                              "renderer=<ridx>|:nodecorate|:size[=WxH]|:window_"
                              "flags=<f>|:keep-aspect]*|:help]") "\n");
         printf("where:\n");
-        color_printf(TBOLD("\td[force]") " - deinterlace (force even for progresive video)\n");
+        color_printf(TBOLD("\td[force]") " - deinterlace (force even for progressive video)\n");
         color_printf(TBOLD("\t      fs") " - fullscreen\n");
         color_printf(TBOLD("\t  <didx>") " - display index, available indices: ");
         sdl2_print_displays();
@@ -366,7 +366,7 @@ show_help(const char *driver)
                 color_printf("%s" TBOLD("%s"), (i == 0 ? "" : ", "), SDL_GetVideoDriver(i));
         }
         color_printf("\n");
-        color_printf(TBOLD("     keep-aspect") " - keep window aspect ratio respecive to the video\n");
+        color_printf(TBOLD("     keep-aspect") " - keep window aspect ratio respective to the video\n");
         color_printf(TBOLD("         novsync") " - disable sync on VBlank\n");
         color_printf(TBOLD("      nodecorate") " - disable window border\n");
         color_printf(
@@ -884,7 +884,7 @@ static bool display_sdl2_putf(void *state, struct video_frame *frame, long long 
 
         assert(s->mod.priv_magic == MAGIC_SDL2);
 
-        if (frame == NULL) { // posion pill
+        if (frame == NULL) { // poison pill
                 SDL_Event event;
                 event.type       = s->sdl_user_new_frame_event;
                 event.user.data1 = NULL;
@@ -892,7 +892,7 @@ static bool display_sdl2_putf(void *state, struct video_frame *frame, long long 
                 return true;
         }
 
-        // fix endianity
+        // fix endianness
         if (frame->color_spec == R10k) {
                 r10k_to_sdl2(frame->tiles[0].data_len / 4,
                              (uint32_t *) frame->tiles[0].data);

--- a/src/video_display/sdl3.c
+++ b/src/video_display/sdl3.c
@@ -497,7 +497,7 @@ show_help(const char *driver, bool full)
             "\t-d sdl[:driver=<drv>]:[full]help") "\n");
         printf("where:\n");
         color_printf(TBOLD(
-            "\td[force]") " - deinterlace (force even for progresive video)\n");
+            "\td[force]") " - deinterlace (force even for progressive video)\n");
         color_printf(TBOLD("\t      fs") " - fullscreen\n");
         color_printf(
             TBOLD("\t  <didx>") " - display index, available indices: ");
@@ -510,7 +510,7 @@ show_help(const char *driver, bool full)
         }
         color_printf("\n");
         color_printf(TBOLD("     keep-aspect") " - keep window aspect ratio "
-                                               "respecive to the video\n");
+                                               "respective to the video\n");
         color_printf(TBOLD("         novsync") " - disable sync on VBlank\n");
         color_printf(TBOLD("      nodecorate") " - disable window border\n");
         color_printf(
@@ -1263,7 +1263,7 @@ display_sdl3_putf(void *state, struct video_frame *frame, long long timeout_ns)
 
         assert(s->mod.priv_magic == MAGIC_SDL3);
 
-        if (frame == NULL) { // posion pill
+        if (frame == NULL) { // poison pill
                 SDL_Event event;
                 event.type       = s->sdl_user_new_frame_event;
                 event.user.data1 = NULL;

--- a/src/video_display/v4l2.c
+++ b/src/video_display/v4l2.c
@@ -37,7 +37,7 @@
 /**
  * @todo
  * * consider using v4l2_ family of functions (such as v4l2_open) - but
- *   v4l2_open currently fails witn v4l2loopback on first open (perhaps because
+ *   v4l2_open currently fails with v4l2loopback on first open (perhaps because
  *   it is non-compliant implementation). We perhaps don't need conversions, so
  *   the advantage would be (in display) perhaps only better verbosity
  *   (v4l2_log_file) and error checking (?).

--- a/src/video_display/vulkan/vulkan_context.cpp
+++ b/src/video_display/vulkan/vulkan_context.cpp
@@ -564,7 +564,7 @@ void VulkanContext::create_swap_chain(vk::SwapchainKHR&& old_swapchain) {
                         return;
                 }
                 catch(std::exception& err){
-                        log_msg(LOG_LEVEL_ERROR, MOD_NAME "Recreation unsuccesful: %s\n", err.what());
+                        log_msg(LOG_LEVEL_ERROR, MOD_NAME "Recreation unsuccessful: %s\n", err.what());
                         device.destroy(old_swapchain);
                         old_swapchain = nullptr;
                         if(attempt + 1 == initialization_attempts){

--- a/src/video_display/vulkan/vulkan_context.hpp
+++ b/src/video_display/vulkan/vulkan_context.hpp
@@ -217,7 +217,7 @@ public:
         }
 
         /**
-         * @param required_extensions   Vulkan instance extensions requested by aplication,
+         * @param required_extensions   Vulkan instance extensions requested by application,
          *                              usually needed for creating vulkan surface
          * @param enable_validation     Enable vulkan validation layers, they should be disabled in release build.
          */

--- a/src/video_display/vulkan/vulkan_display.cpp
+++ b/src/video_display/vulkan/vulkan_display.cpp
@@ -284,8 +284,8 @@ void VulkanDisplay::init(VulkanInstance&& instance, vk::SurfaceKHR surface, uint
 void VulkanDisplay::destroy_format_dependent_resources(){
         conversion_pipeline.destroy(device);
 
-        for(auto& resorces: frame_resources){
-                resorces.converted_image.destroy(device);
+        for(auto& resources: frame_resources){
+                resources.converted_image.destroy(device);
         }
 }
 
@@ -632,7 +632,7 @@ bool VulkanDisplay::display_queued_image() {
         switch (present_result) {
                 case vk::Result::eSuccess:
                         break;
-                // skip recoverable errors, othervise return/throw error 
+                // skip recoverable errors, otherwise return/throw error 
                 case vk::Result::eErrorOutOfDateKHR: 
                 case vk::Result::eSuboptimalKHR: 
                         break;

--- a/src/video_display/vulkan/vulkan_display.hpp
+++ b/src/video_display/vulkan/vulkan_display.hpp
@@ -143,7 +143,7 @@ public:
         bool is_yCbCr_supported() const { return context.is_yCbCr_supported(); }
 
         /**
-         * @brief Hint to vulkan display that some window parameters spicified in struct WindowParameters changed.
+         * @brief Hint to vulkan display that some window parameters specified in struct WindowParameters changed.
          * Thread-safe.
          */
         void window_parameters_changed(WindowParameters new_parameters);

--- a/src/video_display/vulkan/vulkan_sdl2.cpp
+++ b/src/video_display/vulkan/vulkan_sdl2.cpp
@@ -452,7 +452,7 @@ void show_help() {
         col() << SBOLD("\t               d") << " - deinterlace\n";
         col() << SBOLD("\t              fs") << " - fullscreen\n";
         
-        col() << SBOLD("\t     keep-aspect") << " - keep window aspect ratio respecive to the video\n";
+        col() << SBOLD("\t     keep-aspect") << " - keep window aspect ratio respective to the video\n";
         col() << SBOLD("\t        nocursor") << " - hides cursor\n";
         col() << SBOLD("\t      nodecorate") << " - disable window border\n";
         col() << SBOLD("\t         novsync") << " - disable vsync\n";
@@ -486,7 +486,7 @@ struct CodecToVulkanFormat{
 
 // Ultragrid to VulkanDisplay Format mapping
 const std::vector<CodecToVulkanFormat>& get_ug_to_vkd_format_mapping(state_vulkan_sdl2& s){
-        //the backup vkd::Format must follow the corrresponding native vkd::Format 
+        //the backup vkd::Format must follow the corresponding native vkd::Format 
         constexpr std::array<CodecToVulkanFormat, 10> format_mapping {{
                 {RGBA, vkd::Format::RGBA8},
                 {RGB,  vkd::Format::RGB8},

--- a/src/video_display/vulkan/vulkan_sdl3.cpp
+++ b/src/video_display/vulkan/vulkan_sdl3.cpp
@@ -461,7 +461,7 @@ void show_help() {
         col() << SBOLD("\t               d") << " - deinterlace\n";
         col() << SBOLD("\t              fs") << " - fullscreen\n";
         
-        col() << SBOLD("\t     keep-aspect") << " - keep window aspect ratio respecive to the video\n";
+        col() << SBOLD("\t     keep-aspect") << " - keep window aspect ratio respective to the video\n";
         col() << SBOLD("\t        nocursor") << " - hides cursor\n";
         col() << SBOLD("\t      nodecorate") << " - disable window border\n";
         col() << SBOLD("\t         novsync") << " - disable vsync\n";
@@ -495,7 +495,7 @@ struct CodecToVulkanFormat{
 
 // Ultragrid to VulkanDisplay Format mapping
 const std::vector<CodecToVulkanFormat>& get_ug_to_vkd_format_mapping(state_vulkan_sdl3& s){
-        //the backup vkd::Format must follow the corrresponding native vkd::Format 
+        //the backup vkd::Format must follow the corresponding native vkd::Format 
         constexpr std::array<CodecToVulkanFormat, 10> format_mapping {{
                 {RGBA, vkd::Format::RGBA8},
                 {RGB,  vkd::Format::RGB8},

--- a/src/video_display/vulkan/vulkan_transfer_image.hpp
+++ b/src/video_display/vulkan/vulkan_transfer_image.hpp
@@ -194,7 +194,7 @@ public:
         friend class vulkan_display::TransferImage;
         static constexpr uint32_t NO_ID = UINT32_MAX;
 
-        vk::Fence is_available_fence; // is_available_fence becames signalled when gpu releases the image
+        vk::Fence is_available_fence; // is_available_fence becomes signalled when gpu releases the image
 
 private:
         Image2D buffer;

--- a/src/video_frame.h
+++ b/src/video_frame.h
@@ -107,7 +107,7 @@ struct video_frame * vf_alloc_desc_data(struct video_desc desc);
 /**
  * @brief Frees video_frame structure
  *
- * Calls video_frame::data_deleter if defined (suplied by user
+ * Calls video_frame::data_deleter if defined (supplied by user
  * or fiiled by vf_alloc_desc_data()).
  */
 void vf_free(struct video_frame *buf);
@@ -135,7 +135,7 @@ struct tile * vf_get_tile(struct video_frame *buf, int pos);
 /**
  * @brief Makes deep copy of the video frame
  *
- * Copied data are automatically freeed by vf_free()
+ * Copied data are automatically freed by vf_free()
  */
 struct video_frame * vf_get_copy(struct video_frame *original_frame);
 /**
@@ -204,7 +204,7 @@ void vf_restore_metadata(struct video_frame *f, void *);
 unsigned int vf_get_data_len(struct video_frame *f);
 
 /**
- * Fills @param planes with pointers to data accordint to provided
+ * Fills @param planes with pointers to data according to provided
  * spec.
  *
  * Works with planar pixel formats only.

--- a/src/video_rxtx.hpp
+++ b/src/video_rxtx.hpp
@@ -87,7 +87,7 @@ public:
                 return get_receiver_thread() != NULL;
         }
         /**
-         * If overriden, childern must call also video_rxtx::join()
+         * If overridden, children must call also video_rxtx::join()
          */
         virtual void join();
         static video_rxtx *create(std::string const & name, std::map<std::string, param_u> const &);

--- a/src/video_rxtx/h264_rtp.cpp
+++ b/src/video_rxtx/h264_rtp.cpp
@@ -78,7 +78,7 @@ h264_rtp_video_rxtx::h264_rtp_video_rxtx(std::map<std::string, param_u> const &p
 }
 
 /**
- * this function is used to configure ther RTSP server either
+ * this function is used to configure their RTSP server either
  * for video-only or using both audio and video. For audio-only
  * RTSP server, the server is run directly from
  * h264_rtp_video_rxtx::set_audio_spec().

--- a/src/video_rxtx/rtp.cpp
+++ b/src/video_rxtx/rtp.cpp
@@ -136,7 +136,7 @@ rtp_video_rxtx::process_sender_message(struct msg_sender *msg)
                 if (m_fec_state == nullptr) {
                         int rc = 0;
                         if (strstr(msg->fec_cfg, "help") == nullptr) {
-                                MSG(ERROR, "Unable to initalize FEC!\n");
+                                MSG(ERROR, "Unable to initialize FEC!\n");
                                 rc = 1;
                         }
 
@@ -220,7 +220,7 @@ rtp_video_rxtx::rtp_video_rxtx(map<string, param_u> const &params) :
         }
 
         // The idea of doing that is to display help on '-f ldgm:help' even if UG would exit
-        // immediatelly. The encoder is actually created by a message.
+        // immediately. The encoder is actually created by a message.
         check_sender_messages();
 }
 

--- a/src/video_rxtx/ultragrid_rtp.cpp
+++ b/src/video_rxtx/ultragrid_rtp.cpp
@@ -346,7 +346,7 @@ void *ultragrid_rtp_video_rxtx::receiver_loop()
 #ifdef SHARED_DECODER
                                 cp->decoder_state = shared_decoder;
 #else
-                                // we are assigning our display so we make sure it is removed from other dispaly
+                                // we are assigning our display so we make sure it is removed from other display
 
                                 struct multi_sources_supp_info supp_for_mult_sources;
                                 size_t len = sizeof(multi_sources_supp_info);
@@ -412,7 +412,7 @@ void *ultragrid_rtp_video_rxtx::receiver_loop()
         remove_display_from_decoders();
 #endif //  SHARED_DECODER
 
-        // pass posioned pill to display
+        // pass poisoned pill to display
         display_put_frame(m_display_device, NULL, PUTF_BLOCKING);
 
         return 0;

--- a/src/vo_postprocess.c
+++ b/src/vo_postprocess.c
@@ -279,7 +279,7 @@ bool vo_postprocess_get_property(struct vo_postprocess_state *s, int property, v
         }
 
         /** @todo
-         * This is not corrrect in a generic case - the codec may be acceptable for first filter but
+         * This is not correct in a generic case - the codec may be acceptable for first filter but
          * the output of the filter may be unacceptable for the following filter (or later on).
          */
         if (property == VO_PP_PROPERTY_CODECS) {

--- a/src/vo_postprocess/3d-interlaced.c
+++ b/src/vo_postprocess/3d-interlaced.c
@@ -116,7 +116,7 @@ static struct video_frame * interlaced_3d_getf(void *state)
  *
  * @param[in]  state     postprocessor state
  * @param[in]  in        input frame. Must contain exactly 2 tiles
- * @param[out] out       output frame to be written to. Should have only ony tile
+ * @param[out] out       output frame to be written to. Should have only one tile
  * @param[in]  req_pitch requested pitch in buffer
  */
 static bool interlaced_3d_postprocess(void *state, struct video_frame *in, struct video_frame *out, int req_pitch)

--- a/src/vo_postprocess/capture_filter_wrapper.h
+++ b/src/vo_postprocess/capture_filter_wrapper.h
@@ -2,7 +2,7 @@
  * @file   vo_postprocess/capture_filter_wrapper.h
  * @author Martin Pulec     <pulec@cesnet.cz>
  *
- * Wrapper encapsulating caputre filter to video postprocessor.
+ * Wrapper encapsulating capture filter to video postprocessor.
  * In addition to capture filter API, the wrapped module must implement 
  * (void (*set_out_buf)(void *state, char *buffer)) function to provide
  * output buffer to decode to.

--- a/src/vo_postprocess/deinterlace.c
+++ b/src/vo_postprocess/deinterlace.c
@@ -62,7 +62,7 @@ static void usage(_Bool for_postprocessor)
 {
         color_printf(TBOLD("deinterlace_blend") " deinterlaces output video frames "
                         " by applying linear blend on interleaved odd and even "
-                        " fileds.\n\nUsage:\n");
+                        " fields.\n\nUsage:\n");
         if (for_postprocessor) {
                 color_printf(TBOLD(TRED("\t-p deinterlace")) "[:options] | " TBOLD(TRED("-p deinterlace_blend")) "[:options]\n");
         } else {

--- a/src/vo_postprocess/text.c
+++ b/src/vo_postprocess/text.c
@@ -131,7 +131,7 @@ static void * text_init(const char *config) {
         struct state_text *s;
 
         if (strlen(config) == 0 || strcmp(config, "help") == 0) {
-                char desc[] = TBOLD("text") " video postprocess takes as a parameter text to be drawed. "
+                char desc[] = TBOLD("text") " video postprocess takes as a parameter text to be drawn. "
 			 "Colons in text must be escaped with a backslash (see Examples). Spaces may be escaped or the whole argument should be enclosed by quotation marks.\n";
                 color_printf("%s", wrap_paragraph(desc));
                 color_printf("\nUsage:\n");

--- a/src/win32_gl_common.c
+++ b/src/win32_gl_common.c
@@ -3,7 +3,7 @@
  * @author Martin Pulec     <pulec@cesnet.cz>
  *
  * This context has to be run in a separate thread to ensure
- * that DC is stil valid because it is automatically released
+ * that DC is still valid because it is automatically released
  * when thread, where it is created, exits.
  */
 /*
@@ -123,7 +123,7 @@ static void *owner_thread(void *arg) {
 
         int err = glewInit();
         if(err != GLEW_OK) {
-                fprintf(stderr, "Error intializing GLEW.\n");
+                fprintf(stderr, "Error initializing GLEW.\n");
                 goto release_context;
         }
 

--- a/src/x11_common.c
+++ b/src/x11_common.c
@@ -36,11 +36,11 @@
  */
 /**
  * @todo
- * Perhaps remove the whole stuff (+ resouce manager). This used to be used to
+ * Perhaps remove the whole stuff (+ resource manager). This used to be used to
  * solve some crashes with access to X11 from within multiple threads (IIRC
  * RTDXT and X11-based display - GL/SDL?).
  *
- * This may not be needed - individual modues create its own non-shared Xlib
+ * This may not be needed - individual modules create its own non-shared Xlib
  * connection and XInitThreads() is called (this also may not be required).
  */
 
@@ -61,7 +61,7 @@
 struct x11_state {
         Display *display;
         pthread_mutex_t lock;
-        int display_opened_here; /* indicates wheather we opened the display
+        int display_opened_here; /* indicates whether we opened the display
                                           in such a case, we count references and if 0,
                                           we close it */
         int ref_num;

--- a/test/ff_codec_conversions_test.cpp
+++ b/test/ff_codec_conversions_test.cpp
@@ -342,7 +342,7 @@ int ff_codec_conversions_test_yuv444p16le_from_to_rg48()
 /**
  * Just a simple test - use just dummy random data
  * @todo
- * Write more reasonable comparison to check P010LE with different neigboring lines.
+ * Write more reasonable comparison to check P010LE with different neighboring lines.
  */
 int ff_codec_conversions_test_pX10_from_to_v210()
 {

--- a/test/test_video_display.c
+++ b/test/test_video_display.c
@@ -51,7 +51,7 @@ int test_video_display(void)
             ("Testing video hardware detection ......................................... ");
         if (initialize_video_display(NULL, "none", "", 0, NULL, &d) != 0) {
                 printf("FAIL\n");
-                printf("    Cannot intiialize dummy device\n");
+                printf("    Cannot initialize dummy device\n");
                 return -1;
         }
         printf("Ok\n");


### PR DESCRIPTION
## Summary
- Fixed spelling errors found throughout the codebase
- Changes are limited to comments, documentation, and non-functional text
- No code logic or functionality has been modified

## Description
This PR corrects various spelling mistakes that were found across the project:

### Types of corrections made:
- "informations" → "information"
- "prefered" → "preferred" 
- "dispayed" → "displayed"
- "envents" → "events"
- "throught" → "through"
- "alredy" → "already"
- "homogenous" → "homogeneous"
- "containg" → "containing"
- "filaname" → "filename"
- And many other similar corrections

### Files affected:
- 159 files total
- Documentation (*.md files)
- Source code comments (*.c, *.cpp, *.h files)
- Function parameter names and descriptions

## Test plan
- [x] Code compiles successfully on macOS (aarch64-apple-darwin24.5.0)
- [x] No functional changes made - only comments and documentation
- [x] Build tested with `make clean && ./configure && make`