### PR TITLE
vcomp/cmpto_j2k.cpp - Update val comparison to DBL_MAX

### DIFF
--- a/src/video_compress/cmpto_j2k.cpp
+++ b/src/video_compress/cmpto_j2k.cpp
@@ -52,6 +52,7 @@
 #endif // HAVE_CONFIG_H
 
 #include <cassert>
+#include <cfloat>
 #include <cmath>
 #include <climits>
 #include <condition_variable>
@@ -733,7 +734,7 @@ static void usage(bool full) {
 #define ASSIGN_CHECK_VAL(var, str, minval) \
         do { \
                 const double val = unit_evaluate_dbl(str, false, nullptr); \
-                if (std::isnan(val) || val < (minval) || val > UINT_MAX) { \
+                if (std::isnan(val) || val < (minval) || val > DBL_MAX) { \
                         LOG(LOG_LEVEL_ERROR) \
                             << "[J2K] Wrong value " << (str) \
                             << " for " #var "! Value must be >= " << (minval) \


### PR DESCRIPTION
This PR changes `#define ASSIGN_CHECK_VAL(var, str, minval)` to compare `val > DBL_MAX` instead of `val > UINT_MAX`.

This fixes an issue where, when `mem_limit=` exceeds 4.29G, the resulting return from `unit_evaluate_dbl` will exceed UINT_MAX limit and return an unexpected error.