### PR TITLE
fix: SEGV when switching v4l2 devices with switcher:excl_init

### DIFF
--- a/src/video_capture/switcher.c
+++ b/src/video_capture/switcher.c
@@ -241,7 +241,7 @@ vidcap_switcher_init(const struct vidcap_params *params, void **state)
                 }
         }
 
-        s->params = vidcap_params_copy_all(tmp);
+        s->params = vidcap_params_copy_all(params);
 
         vidcap_switcher_register_keyboard_ctl(s);
 


### PR DESCRIPTION
After the init loop advances 'tmp' through all devices via vidcap_params_get_next(), tmp points to the NULL-driver stopper node, not the head of the params list. Passing it to vidcap_params_copy_all() stored only a single stopper node instead of the full device chain.

When a subsequent device switch occurred (via capture.data N), vidcap_params_get_nth() returned NULL for all devices, which was passed to initialize_video_capture() and caused a SEGV in vidcap_params_get_next(NULL).

Use the original 'params' pointer (head of list) instead of the exhausted loop variable.

Bug introduced in commit a2d3eb8c2 ("fixed switcher when :excl_init is used", Sep 2023).